### PR TITLE
new $smarty->debug options

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,4 +1,8 @@
  ===== 3.1.22-dev ===== (xx.xx.2014)
+ 04.11.2014
+ - new feature $smarty->debug = true; => overwrite existing Debug Console window (old behaviour)
+               $smarty->debug = 2; => individual Debug Console window by template name
+ 
  03.11.2014
  - bugfix Debug Console did not show included subtemplates since 3.1.17 (forum 25301)
  - bugfix Modifier debug_print_var did not limit recursion or prevent recursive object display at Debug Console

--- a/libs/debug.tpl
+++ b/libs/debug.tpl
@@ -152,7 +152,8 @@
     </html>
 {/capture}
 <script type="text/javascript">
-    {$id = $template_name|default:''|md5}
+    {$id = ''}
+    {if $display_mode}{$id = $template_name|md5}{/if}
     _smarty_console = window.open("", "console{$id}", "width=680,height=600,resizable,scrollbars=yes");
     _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
     _smarty_console.document.close();

--- a/libs/sysplugins/smarty_internal_debug.php
+++ b/libs/sysplugins/smarty_internal_debug.php
@@ -221,6 +221,7 @@ class Smarty_Internal_Debug extends Smarty_Internal_Data
         $_template->assign('assigned_vars', $_assigned_vars);
         $_template->assign('config_vars', $_config_vars);
         $_template->assign('execution_time', microtime(true) - $smarty->start_time);
+        $_template->assign('display_mode', $smarty->debugging == 2 || !$full);
         echo $_template->fetch();
         if ($full) {
             self::$ignore_uid = array();


### PR DESCRIPTION
- new feature $smarty->debug = true; => overwrite existing Debug Console
  window (old behaviour)
  $smarty->debug = 2; => individual Debug Console window by template name
