### PR TITLE
Commit 7b2a2c4a883ba745759fb5db26ab8134a5ae282b changed the constant pro...

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/libs/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -79,8 +79,11 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                     $compiler->trigger_template_error("(secure mode) constants not permitted");
                     break;
                 }
-
-                return "@constant({$_index[1]})";
+                if( strpos( $_index[1], '$') === false ){
+                    return "@constant('{$_index[1]}')";
+                } else {
+                    return "@constant({$_index[1]})";
+                }
 
             case 'config':
                 if (isset($_index[2])) {


### PR DESCRIPTION
Commit 7b2a2c4a883ba745759fb5db26ab8134a5ae282b changed the constant processing to allow a variable in the $smarty.const but this broke the normal callout. Change allows both methods.
