### PR TITLE
Dont load unnecessary files with composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,11 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Export-ignore files
+/demo                           export-ignore
+.gitattributes                  export-ignore
+.gitignore                      export-ignore
+README                          export-ignore
+README.md                       export-ignore
+*.txt                           export-ignore


### PR DESCRIPTION
Files that are not necessary for package distribution should not
be part of distribution package.
This change reduce amount of downloaded content by composer
with --prefer-dist option