### PR TITLE
Added properties $iteration and $total to Smarty_Variable

### DIFF
--- a/libs/sysplugins/smarty_variable.php
+++ b/libs/sysplugins/smarty_variable.php
@@ -27,7 +27,19 @@ class Smarty_Variable
      * @var int
      */
     public $scope = Smarty::SCOPE_LOCAL;
-
+    /**
+     * the iteration the value is in (if it is used in a loop)
+     *
+     * @var int
+     */
+    public $iteration = 0;
+    /**
+     * the total number of elements this varaible iterates over (if it is used in a loop)
+     *
+     * @var int
+     */
+    public $total = 0;
+    
     /**
      * create Smarty variable object
      *


### PR DESCRIPTION
Sometimes, but not always, the notice 
> Undefined property: Smarty_Variable::$iteration

 and 

> Undefined property: Smarty_Variable::$total

are thrown. I cannot tell why this happens only some times, but I found, that this properties are dynamically set.