### PR TITLE
In a dev environment (no caching, compilecheck is true forcecompile i…

### DIFF
--- a/libs/sysplugins/smarty_internal_config_file_compiler.php
+++ b/libs/sysplugins/smarty_internal_config_file_compiler.php
@@ -100,7 +100,7 @@ class Smarty_Internal_Config_File_Compiler
     public function compileTemplate(Smarty_Internal_Template $template)
     {
         $this->template = $template;
-        $this->template->properties['file_dependency'][$this->template->source->uid] = array($this->template->source->name, $this->template->source->getTimeStamp(), $this->template->source->type);
+        $this->template->properties['file_dependency'][$this->template->source->uid] = array($this->template->source->filepath, $this->template->source->getTimeStamp(), $this->template->source->type);
         if ($this->smarty->debugging) {
             Smarty_Internal_Debug::start_compile($this->template);
         }


### PR DESCRIPTION
In a dev environment (no caching, compilecheck is true and forcecompile is false)

Smarty seems to always compile config files, templates are fine and work as expected.

The Config compiler is, I suspect, incorrectly using the Smarty_Template_Config::source['name'] when creating the Smarty_Internal_Template 'file_dependency' property which is added to the compiled file (line 103 of smarty_internal_config_file_compiler.php)

extract from generated compiled file (outputs only the filename):

/*%%SmartyHeaderCode:%%*/
if(!defined('SMARTY_DIR')) exit('no direct access allowed');
$_valid = $_smarty_tpl->decodeProperties(array (
  'file_dependency' =>
  array (
    '4041b1cbe642f4f76559df8a8a185706cb1aa20a' =>
    array (
      0 => 'eng.conf',
      1 => 1437128022,
      2 => 'file',
    ),
  ),
  'nocache_hash' => '',
  'has_nocache_code' => false,
  'version' => '3.1.27',
  'unifunc' => 'content_55a993e6049fd7_92979412',
),false);
/*/%%SmartyHeaderCode%%*/

in comparison

The Smarty_Internal_TemplateCompilerBase is using the Smarty_Internal_Template::source['filepath'] when creating the Smarty_Internal_Template 'file_dependency' property which is added to the compiled file (line 365 of smarty_internal_templatecompilerbase.php)

extract from generated compiled file (outputs the full filepath):

/*%%SmartyHeaderCode:2063955a992f58bf046_88173994%%*/
if(!defined('SMARTY_DIR')) exit('no direct access allowed');
$_valid = $_smarty_tpl->decodeProperties(array (
  'file_dependency' =>
  array (
    '96fae2fa79884f128f6e0e578e87a1a3a9ff3715' =>
    array (
      0 => 'C:\\git_repos\\closeit\\src\\templates\\test.tpl',
      1 => 1437173997,
      2 => 'file',
    ),
  ),
  'nocache_hash' => '2063955a992f58bf046_88173994',
  'has_nocache_code' => false,
  'version' => '3.1.27',
  'unifunc' => 'content_55a993d60dec46_93048876',
),false);
/*/%%SmartyHeaderCode%%*/

This causes the check 'if ($this->source->filepath == $_file_to_check[0] && isset($this->source->timestamp))' on line 605 of 'smarty_internal_template.php' to fail, and as such compile the config file again