### PR TITLE
Update README with correct plugin method signature

### DIFF
--- a/README
+++ b/README
@@ -460,12 +460,13 @@ included template.
 PLUGINS
 =======
 
-Smarty3 are following the same coding rules as in Smarty2. 
-The only difference is that the template object is passed as additional third parameter.
+Smarty 3 plugins follow the same coding rules as in Smarty 2. 
+The main difference is that the template object is now passed in place of the smarty object. 
+The smarty object can be still be accessed through $template->smarty.
 
-smarty_plugintype_name (array $params, object $smarty, object $template)
+smarty_plugintype_name (array $params, Smarty_Internal_Template $template)
 
-The Smarty 2 plugins are still compatible as long as they do not make use of specific Smarty2 internals.
+The Smarty 2 plugins are still compatible as long as they do not make use of specific Smarty 2 internals.
 
 
 TEMPLATE INHERITANCE:


### PR DESCRIPTION
The existing README states that 3 params are passed for plugins (params, smarty, template) but the smarty object was actually removed long ago. This update corrects this.