### PR TITLE
do not load "Autoloader" from include path

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -79,7 +79,7 @@ if (!defined('SMARTY_RESOURCE_DATE_FORMAT')) {
  */
 if (!class_exists('Smarty_Autoloader', false)) {
     if (!class_exists('Smarty_Internal_Data', true)) {
-        require_once 'Autoloader.php';
+        require_once dirname(__FILE__) . '/Autoloader.php';
         Smarty_Autoloader::registerBC();
     }
 }


### PR DESCRIPTION
loading it from include path (without abs path) can be dangerous, can load some other project's Autoloader.php instead the right one.