### PR TITLE
*Change: {fetch} now can actually use the compiler if the user specified

### DIFF
--- a/libs/plugins/function.fetch.php
+++ b/libs/plugins/function.fetch.php
@@ -207,7 +207,15 @@ function smarty_function_fetch($params, $template)
             return;
         }
     } else {
-        $content = @file_get_contents($params['file']);
+        $file = $params['file'];
+        $asTemplate = (isset($params['asTemplate'])) ? (bool) $params['asTemplate'] : false;
+
+        if ($asTemplate === true) {
+            $content = $template->fetch($file);
+        } else {
+            $content = @file_get_contents($file);
+        }
+
         if ($content === false) {
             throw new SmartyException("{fetch} cannot read resource '" . $params['file'] . "'");
         }


### PR DESCRIPTION
Hy,

today I try to use this function and noticed, that only fetch content and not compile the fetched file content. The documentation on {include} says that is usable as fetch (Fetch template into a variable using assign), but i think is not the expected behaviour of this function. This behaviour expected by {fetch} (I think). 

I slightly modified the {fetch} behaviour, introduced a new parameter (asTemplate) and if this TRUE use the compiler to copile the given template. 

This modification not break the existing API.