### PR TITLE
Restored Smarty_Internal_Data::getVariable()

### DIFF
--- a/libs/sysplugins/smarty_internal_data.php
+++ b/libs/sysplugins/smarty_internal_data.php
@@ -188,6 +188,21 @@ class Smarty_Internal_Data
     }
 
     /**
+     * gets the object of a Smarty variable
+     *
+     * @param  string  $variable       the name of the Smarty variable
+     * @param  Smarty_Internal_Data  $_ptr           optional pointer to data object
+     * @param  boolean $searchParents search also in parent data
+     * @param bool     $error_enable
+     *
+     * @return Smarty_Variable|Smarty_Undefined_Variable the object of the variable
+     * @deprecated since 3.1.28 please use Smarty_Internal_Data::getTemplateVars() instead.
+     */
+    public function getVariable($variable = null, Smarty_Internal_Data $_ptr = null, $searchParents = true, $error_enable = true){
+        return $this->ext->getTemplateVars->_getVariable($this, $variable, $_ptr, $searchParents, $error_enable);
+    }
+    
+    /**
      * Follow the parent chain an merge template and config variables
      *
      * @param \Smarty_Internal_Data|null $data


### PR DESCRIPTION
I added `Smarty_Internal_Data::getVariable()` which equally uses lazy loaded external plugin as  `getTemplateVars()`. I also added a deprecation message so that it is clear it will be removed soon. 

As it is  version 3.1.28 breaks existing code written in 3.1.27, which violates the SemVer principle.