### PR TITLE
Update smarty_internal_compile_capture.php

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_capture.php
+++ b/libs/sysplugins/smarty_internal_compile_capture.php
@@ -74,7 +74,7 @@ class Smarty_Internal_Compile_Capture extends Smarty_Internal_CompileBase
         if (!$name) {
             $compiler->trigger_template_error("missing or illegal \$smarty.{$tag} name attribute", null, true);
         }
-        return "isset(\$_smarty_tpl->_cache['__smarty_capture']['{$name}']) ? \$_smarty_tpl->_cache['__smarty_capture']['{$name}'] : null";
+        return "(isset(\$_smarty_tpl->_cache['__smarty_capture']['{$name}']) ? \$_smarty_tpl->_cache['__smarty_capture']['{$name}'] : null)";
     }
 }
 


### PR DESCRIPTION
Added missing ().

Without them "{if}", with several "$smarty.capture.X" in condition, generates incorrect code.

e.g. before this change, smarty code

```
{if $smarty.capture.A || $smarty.capture.B}
```

generates code

```php
<?php if (isset($_smarty_tpl->_cache['__smarty_capture']['A']) ? $_smarty_tpl->_cache['__smarty_capture']['A'] : null || isset($_smarty_tpl->_cache['__smarty_capture']['B']) ? $_smarty_tpl->_cache['__smarty_capture']['B'] : null) {?>
```
which evaluates incorrectly.

After this change generated code is

```php
<?php if ((isset($_smarty_tpl->_cache['__smarty_capture']['A']) ? $_smarty_tpl->_cache['__smarty_capture']['A'] : null) || (isset($_smarty_tpl->_cache['__smarty_capture']['B']) ? $_smarty_tpl->_cache['__smarty_capture']['B'] : null)) {?>
```
which evaluates correctly.