### PR TITLE
set correct path to template in CompileAll

### DIFF
--- a/libs/sysplugins/smarty_internal_method_compilealltemplates.php
+++ b/libs/sysplugins/smarty_internal_method_compilealltemplates.php
@@ -69,7 +69,7 @@ class Smarty_Internal_Method_CompileAllTemplates
                 if (!substr_compare($_file, $extension, - strlen($extension)) == 0) {
                     continue;
                 }
-                if ($_fileinfo->getPath() == !substr($_dir, 0, - 1)) {
+                if ($_fileinfo->getPath() !== substr($_dir, 0, - 1)) {
                     $_file = substr($_fileinfo->getPath(), strlen($_dir)) . DS . $_file;
                 }
                 echo "\n<br>", $_dir, '---', $_file;


### PR DESCRIPTION
When the template is in a subdirectory of the sourcedir, the the template could not be loaded