### PR TITLE
Minor optimization for Smarty_Internal_Data::assign()

### DIFF
--- a/libs/sysplugins/smarty_internal_data.php
+++ b/libs/sysplugins/smarty_internal_data.php
@@ -95,9 +95,7 @@ class Smarty_Internal_Data
     {
         if (is_array($tpl_var)) {
             foreach ($tpl_var as $_key => $_val) {
-                if ($_key != '') {
-                    $this->assign($_key, $_val, $nocache);
-                }
+                $this->assign($_key, $_val, $nocache);
             }
         } else {
             if ($tpl_var != '') {


### PR DESCRIPTION
Removed the extra if block, when an array has been given as the $tpl_var argument, because in the else block there is already a "not empty check".