### PR TITLE
Allow positional parameters in custom functions

### DIFF
--- a/libs/sysplugins/smarty_internal_compilebase.php
+++ b/libs/sysplugins/smarty_internal_compilebase.php
@@ -86,8 +86,9 @@ abstract class Smarty_Internal_CompileBase
                 } elseif (isset($this->shorttag_order[ $key ])) {
                     $_indexed_attr[ $this->shorttag_order[ $key ] ] = $mixed;
                 } else {
-                    // too many shorthands
-                    $compiler->trigger_template_error('too many shorthand attributes', null, true);
+                    // Allow too many shorthands
+                    $_indexed_attr[] = $mixed;
+                    //$compiler->trigger_template_error('too many shorthand attributes', null, true);
                 }
                 // named attribute
             } else {


### PR DESCRIPTION
This patch is what we've been using for some time for functions in Core Plus such as the date function, `{date $model.created}`.
It adds arguments assigned onto the parameter stack in the next index based on the order that they're set in.

This would fix #164