### PR TITLE
avoid opcache_invalidate to result in ErrorException

### DIFF
--- a/libs/sysplugins/smarty_template_compiled.php
+++ b/libs/sysplugins/smarty_template_compiled.php
@@ -124,7 +124,7 @@ class Smarty_Template_Compiled extends Smarty_Template_Resource_Base
      */
     private function loadCompiledTemplate(Smarty_Internal_Template $_smarty_tpl)
     {
-        if (function_exists('opcache_invalidate')) {
+        if (function_exists('opcache_invalidate') && empty(ini_get("opcache.restrict_api"))) {
             opcache_invalidate($this->filepath, true);
         } elseif (function_exists('apc_compile_file')) {
             apc_compile_file($this->filepath);

--- a/libs/sysplugins/smarty_template_compiled.php
+++ b/libs/sysplugins/smarty_template_compiled.php
@@ -124,7 +124,7 @@ class Smarty_Template_Compiled extends Smarty_Template_Resource_Base
      */
     private function loadCompiledTemplate(Smarty_Internal_Template $_smarty_tpl)
     {
-        if (function_exists('opcache_invalidate') && empty(ini_get("opcache.restrict_api"))) {
+        if (function_exists('opcache_invalidate') && strlen(ini_get("opcache.restrict_api")) < 1) {
             opcache_invalidate($this->filepath, true);
         } elseif (function_exists('apc_compile_file')) {
             apc_compile_file($this->filepath);


### PR DESCRIPTION
calling opcache_invalidate will result in ErrorException (Zend OPcache API is restricted by "restrict_api") if opcache.restrict_api is not empty and script is used outside of allowed path. I suggest that there is check which makes sure that function is not called unless opcache.restrict_api is empty - for compatibility with shared webhostings where this configuration property might be common.