### PR TITLE
Fix define method in registered objects

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_private_object_function.php
+++ b/libs/sysplugins/smarty_internal_compile_private_object_function.php
@@ -49,7 +49,7 @@ class Smarty_Internal_Compile_Private_Object_Function extends Smarty_Internal_Co
             unset($_attr[ 'assign' ]);
         }
         // method or property ?
-        if (method_exists($compiler->smarty->registered_objects[ $tag ][ 0 ], $method)) {
+        if (is_callable(array($compiler->smarty->registered_objects[ $tag ][ 0 ], $method))) {
             // convert attributes into parameter array string
             if ($compiler->smarty->registered_objects[ $tag ][ 2 ]) {
                 $_paramsArray = array();


### PR DESCRIPTION
This changes need to correct definition methods in registered objects with `__call` method;

```
class ObjectWithMagicCall {
    public function __call() {
         ...
         return 'some-value';
    }
}
```

```
$smarty -> registerObject('registered_object', new ObjectWithMagicCall())
```

if we use method in template  `{registered_object->magicMethod assign="res"}`, method magicMethod will be defined as property.
