### PR TITLE
exclude files from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,11 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# exclude from git export
+/travis.ini export-ignore
+/composer.json export-ignore
+/.travis.yml export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/lexer/ export-ignore


### PR DESCRIPTION
add files to be excluded from git export

visible when used via composer --prefer-dist or just by downloading .zip or .tar.gz from github releases page
