### PR TITLE
Fix annotation for addPluginsDir()

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -948,7 +948,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * Adds directory of plugin files
      *
-     * @param null|array $plugins_dir
+     * @param null|array|string $plugins_dir
      *
      * @return Smarty current Smarty instance for chaining
      */


### PR DESCRIPTION
Param of [addPluginsDir()](http://www.smarty.net/docs/en/api.add.plugins.dir.tpl) can be null, array or a string. Fixed annotation so there will be no IDE warnings.