### PR TITLE
Added sorting filters by name, that allows to order filters by passin…

### DIFF
--- a/libs/sysplugins/smarty_internal_runtime_filterhandler.php
+++ b/libs/sysplugins/smarty_internal_runtime_filterhandler.php
@@ -59,6 +59,8 @@ class Smarty_Internal_Runtime_FilterHandler
         }
         // loop over registered filters of specified type
         if (!empty($template->smarty->registered_filters[$type])) {
+            // Sort filters by name
+            ksort($template->smarty->registered_filters[$type]);
             foreach ($template->smarty->registered_filters[$type] as $key => $name) {
                 $content = call_user_func($template->smarty->registered_filters[$type][$key], $content, $template);
             }


### PR DESCRIPTION
I faced a special problem, where FILTER A needs to be called after FILTER B. The solution was quite simple by keysorting all the filters before applying.

Priorizing filters can be done by:
```
$smarty->registerFilter('output',$callback,'2-FILTER-A');
$smarty->registerFilter('output',$callback,'1-FILTER-B');
```