### PR TITLE
Refers smarty-php/smarty#344

### DIFF
--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -927,7 +927,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
             $_tag = explode('_', $tag);
             $_tag = array_map('ucfirst', $_tag);
             $class_name = 'Smarty_Internal_Compile_' . implode('_', $_tag);
-            if (class_exists($class_name) &&
+            if ($this->smarty->loadPlugin($class_name) &&
                 (!isset($this->smarty->security_policy) || $this->smarty->security_policy->isTrustedTag($tag, $this))
             ) {
                 self::$_tag_objects[ $tag ] = new $class_name;


### PR DESCRIPTION
Should not call class_exists in Smarty_Internal_TemplateCompilerBase::getTagCompiler() or Smarty_Internal_TemplateCompilerBase::callTagCompiler()