### PR TITLE
spelling fixes

### DIFF
--- a/INHERITANCE_RELEASE_NOTES.txt
+++ b/INHERITANCE_RELEASE_NOTES.txt
@@ -63,7 +63,7 @@ the compiled code of {include} subtemplates gets also merged in compiled inherit
 Merging the code into a single compile template has some drawbacks.
 1. You could not use variable file names in {include} Smarty would use the {include} of compilation time.
 2. You could not use individual compile_id in {include}
-3. Seperate caching of subtemplate was not possible
+3. Separate caching of subtemplate was not possible
 4. Any change of the template directory structure between calls was not necessarily seen.
 
 Starting with 3.1.15 some of the above conditions got checked and resulted in an exception. It turned out

--- a/NEW_FEATURES.txt
+++ b/NEW_FEATURES.txt
@@ -45,7 +45,7 @@ Smarty 3.1.30
         {/foreach}
 
     The {foreach} loop is rendered while processing the compiled template, but $current is a nocache
-    variable. Normally the {if $current==$item.id} would fail as the $item variable is unkown in the 
+    variable. Normally the {if $current==$item.id} would fail as the $item variable is unknown in the 
     cached template. {make_nocache $item} does make the current $item value known in thee cached template.
 
     {make_nocache} is ignored when caching is disabled or the variable does exists as nocache variable.

--- a/README
+++ b/README
@@ -260,12 +260,12 @@ Example: {$object->method1($x)->method2($y)}
 {for} tag added for looping (replacement for {section} tag):
 {for $x=0, $y=count($foo); $x<$y; $x++}  ....  {/for}
 Any number of statements can be used separated by comma as the first
-inital expression at {for}.
+initial expression at {for}.
 
 {for $x = $start to $end step $step} ... {/for}is in the SVN now .
 You can use also
 {for $x = $start to $end} ... {/for}
-In this case the step value will be automaticall 1 or -1 depending on the start and end values.
+In this case the step value will be automatically 1 or -1 depending on the start and end values.
 Instead of $start and $end you can use any valid expression.
 Inside the loop the following special vars can be accessed:
 $x@iteration = number of iteration
@@ -473,7 +473,7 @@ TEMPLATE INHERITANCE:
 =====================
 
 With template inheritance you can define blocks, which are areas that can be
-overriden by child templates, so your templates could look like this: 
+overridden by child templates, so your templates could look like this: 
 
 parent.tpl:
 <html>
@@ -508,8 +508,8 @@ grandchild.tpl:
 
 We redefined all the blocks here, however in the title block we used {$smarty.block.parent},
 which tells Smarty to insert the default content from the parent template in its place.
-The content block was overriden to display the image files, and page-title has also be 
-overriden to display a completely different title. 
+The content block was overridden to display the image files, and page-title has also be 
+overridden to display a completely different title. 
 
 If we render grandchild.tpl we will get this: 
 <html>

--- a/SMARTY_3.0_BC_NOTES.txt
+++ b/SMARTY_3.0_BC_NOTES.txt
@@ -1,5 +1,5 @@
 == Smarty2 backward compatibility ==
-All Smarty2 specific API functions and deprecated functionallity has been moved
+All Smarty2 specific API functions and deprecated functionality has been moved
 to the SmartyBC class.
 
 == {php} Tag ==

--- a/SMARTY_3.1_NOTES.txt
+++ b/SMARTY_3.1_NOTES.txt
@@ -50,7 +50,7 @@ The escape modifier now knows the $double_encode option, which will
 prevent entities from being encoded again.
 
 The capitalize modifier now know the $lc_rest option, which makes sure
-all letters following a captial letter are lower-cased.
+all letters following a capital letter are lower-cased.
 
 The count_sentences modifier now accepts (.?!) as
 legitimate endings of a sentence - previously only (.) was
@@ -126,7 +126,7 @@ run on variable output.
 SYNTAX:
 {setfilter filter1|filter2|filter3....}
 Smarty3 will lookup up matching filters in the following search order:
-1. varibale filter plugin in plugins_dir.
+1. variable filter plugin in plugins_dir.
 2. a valid modifier. A modifier specification will also accept
 additional parameter like filter2:'foo'
 3. a PHP function

--- a/demo/plugins/cacheresource.pdo.php
+++ b/demo/plugins/cacheresource.pdo.php
@@ -91,7 +91,7 @@ class Smarty_CacheResource_Pdo extends Smarty_CacheResource_Custom
      * 
      * @param PDO $pdo PDO : active connection 
      * @param string $table : table (or view) name 
-     * @param string $database : optionnal - if table is located in another db 
+     * @param string $database : optional - if table is located in another db 
      */
     public function __construct(PDO $pdo, $table, $database = null)
     {

--- a/lexer/smarty_internal_templateparser.y
+++ b/lexer/smarty_internal_templateparser.y
@@ -1263,7 +1263,7 @@ arrayelement(res)    ::=  expr(e). {
 
 
 //
-// double qouted strings
+// double quoted strings
 //
 doublequoted_with_quotes(res) ::= QUOTE QUOTE. {
     res = "''";

--- a/libs/plugins/function.mailto.php
+++ b/libs/plugins/function.mailto.php
@@ -20,7 +20,7 @@
  *                             * none : no encoding (default)
  *                             * javascript : encode with javascript
  *                             * javascript_charcode : encode with javascript charcode
- *                             * hex : encode with hexidecimal (no javascript)
+ *                             * hex : encode with hexadecimal (no javascript)
  * - cc         - (optional) - address(es) to carbon copy
  * - bcc        - (optional) - address(es) to blind carbon copy
  * - subject    - (optional) - e-mail subject

--- a/libs/sysplugins/smarty_internal_compile_private_registered_function.php
+++ b/libs/sysplugins/smarty_internal_compile_private_registered_function.php
@@ -44,7 +44,7 @@ class Smarty_Internal_Compile_Private_Registered_Function extends Smarty_Interna
         } else {
             $tag_info = $compiler->default_handler_plugins[ Smarty::PLUGIN_FUNCTION ][ $tag ];
         }
-        // not cachable?
+        // not cacheable?
         $compiler->tag_nocache = $compiler->tag_nocache || !$tag_info[ 1 ];
         // convert attributes into parameter array string
         $_paramsArray = array();

--- a/libs/sysplugins/smarty_internal_runtime_inheritance.php
+++ b/libs/sysplugins/smarty_internal_runtime_inheritance.php
@@ -100,7 +100,7 @@ class Smarty_Internal_Runtime_Inheritance
      * - if outer level is reached flush output buffer and switch to wait for parent template state
      *
      * @param \Smarty_Internal_Template $tpl
-     * @param null|string               $template optinal name of inheritance parent template
+     * @param null|string               $template optional name of inheritance parent template
      * @param null|string               $uid      uid of inline template
      * @param null|string               $func     function call name of inline template
      */

--- a/libs/sysplugins/smarty_internal_runtime_updatescope.php
+++ b/libs/sysplugins/smarty_internal_runtime_updatescope.php
@@ -82,7 +82,7 @@ class Smarty_Internal_Runtime_UpdateScope
     }
 
     /**
-     * Update varibale in other scope
+     * Update variable in other scope
      *
      * @param array     $tpl_vars template variable array
      * @param \Smarty_Internal_Template $from


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.