### PR TITLE
Fixed broken script tags

### DIFF
--- a/libs/sysplugins/smarty_internal_parsetree_template.php
+++ b/libs/sysplugins/smarty_internal_parsetree_template.php
@@ -101,7 +101,7 @@ class Smarty_Internal_ParseTree_Template extends Smarty_Internal_ParseTree
                 if ($subtree == '') {
                     continue;
                 }
-                $code .= preg_replace('/((<%)|(%>)|(<\?php)|(<\?)|(\?>)|(<\/?script))/', "<?php echo '\$1'; ?>\n",
+                $code .= preg_replace('/((<%)|(%>)|(<\?php)|(<\?)|(\?>))/', "<?php echo '\$1'; ?>\n",
                                       $subtree);
                 continue;
             }


### PR DESCRIPTION
Fixes usage when using such HTML inside a Smarty Template...

```
<script type="text/javascript">
    
</script>
```

to_smarty_php function replaces the type property to:

```
<?php echo '<script'; ?>
 type="text/javascript">
<?php echo '</script'; ?>
```

which results to:

```
<scripttype="text/javascript">
</script>
```