### PR TITLE
Check if ini_get/ini_set is not disabled before using it

### DIFF
--- a/libs/sysplugins/smarty_internal_cacheresource_file.php
+++ b/libs/sysplugins/smarty_internal_cacheresource_file.php
@@ -108,7 +108,8 @@ class Smarty_Internal_CacheResource_File extends Smarty_CacheResource
         if ($_template->smarty->ext->_writeFile->writeFile($_template->cached->filepath, $content,
                                                            $_template->smarty) === true
         ) {
-            if (function_exists('opcache_invalidate') && strlen(ini_get("opcache.restrict_api")) < 1) {
+            if (function_exists('opcache_invalidate')
+                && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)) {
                 opcache_invalidate($_template->cached->filepath, true);
             } elseif (function_exists('apc_compile_file')) {
                 apc_compile_file($_template->cached->filepath);

--- a/libs/sysplugins/smarty_internal_config_file_compiler.php
+++ b/libs/sysplugins/smarty_internal_config_file_compiler.php
@@ -117,7 +117,9 @@ class Smarty_Internal_Config_File_Compiler
         /* @var Smarty_Internal_ConfigFileParser $this->parser */
         $this->parser = new $this->parser_class($this->lex, $this);
 
-        if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
+        if (function_exists('mb_internal_encoding')
+            && function_exists('ini_get')
+            && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('ASCII');
         } else {

--- a/libs/sysplugins/smarty_internal_method_clearcompiledtemplate.php
+++ b/libs/sysplugins/smarty_internal_method_clearcompiledtemplate.php
@@ -111,7 +111,8 @@ class Smarty_Internal_Method_ClearCompiledTemplate
 
                 if ($unlink && @unlink($_filepath)) {
                     $_count ++;
-                    if (function_exists('opcache_invalidate') && strlen(ini_get("opcache.restrict_api")) < 1) {
+                    if (function_exists('opcache_invalidate')
+                        && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)) {
                         opcache_invalidate($_filepath, true);
                     }
                 }

--- a/libs/sysplugins/smarty_internal_resource_php.php
+++ b/libs/sysplugins/smarty_internal_resource_php.php
@@ -37,7 +37,7 @@ class Smarty_Internal_Resource_Php extends Smarty_Internal_Resource_File
      */
     public function __construct()
     {
-        $this->short_open_tag = ini_get('short_open_tag');
+        $this->short_open_tag = function_exists('ini_get') ? ini_get('short_open_tag') : 1;
     }
 
     /**
@@ -79,13 +79,17 @@ class Smarty_Internal_Resource_Php extends Smarty_Internal_Resource_File
         extract($_template->getTemplateVars());
 
         // include PHP template with short open tags enabled
-        ini_set('short_open_tag', '1');
+        if (function_exists('ini_set')) {
+            ini_set('short_open_tag', '1');
+        }
         /** @var Smarty_Internal_Template $_smarty_template
          * used in included file
          */
         $_smarty_template = $_template;
         include($source->filepath);
-        ini_set('short_open_tag', $this->short_open_tag);
+        if (function_exists('ini_set')) {
+            ini_set('short_open_tag', $this->short_open_tag);
+        }
     }
 
     /**

--- a/libs/sysplugins/smarty_internal_runtime_cacheresourcefile.php
+++ b/libs/sysplugins/smarty_internal_runtime_cacheresourcefile.php
@@ -125,7 +125,8 @@ class Smarty_Internal_Runtime_CacheResourceFile
                         }
                     }
                     $_count += @unlink($_filepath) ? 1 : 0;
-                    if (function_exists('opcache_invalidate') && strlen(ini_get("opcache.restrict_api")) < 1) {
+                    if (function_exists('opcache_invalidate')
+                        && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)) {
                         opcache_invalidate($_filepath, true);
                     }
                 }

--- a/libs/sysplugins/smarty_internal_smartytemplatecompiler.php
+++ b/libs/sysplugins/smarty_internal_smartytemplatecompiler.php
@@ -94,7 +94,9 @@ class Smarty_Internal_SmartyTemplateCompiler extends Smarty_Internal_TemplateCom
         if ($isTemplateSource && $this->template->caching) {
             $this->parser->insertPhpCode("<?php\n\$_smarty_tpl->compiled->nocache_hash = '{$this->nocache_hash}';\n?>\n");
         }
-        if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
+        if (function_exists('mb_internal_encoding')
+            && function_exists('ini_get')
+            && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('ASCII');
         } else {

--- a/libs/sysplugins/smarty_template_compiled.php
+++ b/libs/sysplugins/smarty_template_compiled.php
@@ -126,7 +126,8 @@ class Smarty_Template_Compiled extends Smarty_Template_Resource_Base
      */
     private function loadCompiledTemplate(Smarty_Internal_Template $_smarty_tpl)
     {
-        if (function_exists('opcache_invalidate') && strlen(ini_get("opcache.restrict_api")) < 1) {
+        if (function_exists('opcache_invalidate')
+            && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)) {
             opcache_invalidate($this->filepath, true);
         } elseif (function_exists('apc_compile_file')) {
             apc_compile_file($this->filepath);


### PR DESCRIPTION
ini_get/set may often be disabled in production environments, causing warnings to be generated (and NULL to be returned). This change checks that ini_get/set is usable (otherwise function_exists will return FALSE) before using it, preventing the warnings while introducing no functional change.