### PR TITLE
Use PHP_VERSION constant instead of phpversion()

### DIFF
--- a/libs/Autoloader.php
+++ b/libs/Autoloader.php
@@ -76,7 +76,7 @@ class Smarty_Autoloader
         self::$SMARTY_DIR = defined('SMARTY_DIR') ? SMARTY_DIR : dirname(__FILE__) . DIRECTORY_SEPARATOR;
         self::$SMARTY_SYSPLUGINS_DIR = defined('SMARTY_SYSPLUGINS_DIR') ? SMARTY_SYSPLUGINS_DIR :
             self::$SMARTY_DIR . 'sysplugins' . DIRECTORY_SEPARATOR;
-        if (version_compare(phpversion(), '5.3.0', '>=')) {
+        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
             spl_autoload_register(array(__CLASS__, 'autoload'), true, $prepend);
         } else {
             spl_autoload_register(array(__CLASS__, 'autoload'));


### PR DESCRIPTION
`phpversion()` may often be disabled in production environments, causing warnings to be generated. Instead `PHP_VERSION` will always be set with the same value and thus having the same effect as `phpversion()` when used in `version_compare()`.