### PR TITLE
Call preg_match with '0' as flags-parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: trusty
-
 php:
   - 5.3
   - 5.4

--- a/libs/sysplugins/smarty_internal_templatelexer.php
+++ b/libs/sysplugins/smarty_internal_templatelexer.php
@@ -307,7 +307,7 @@ class Smarty_Internal_Templatelexer
         }
 
         do {
-            if (preg_match($this->yy_global_pattern1, $this->data, $yymatches, null, $this->counter)) {
+            if (preg_match($this->yy_global_pattern1, $this->data, $yymatches, 0, $this->counter)) {
                 if (!isset($yymatches[ 0 ][ 1 ])) {
                     $yymatches = preg_grep("/(.|\s)+/", $yymatches);
                 } else {
@@ -444,7 +444,7 @@ class Smarty_Internal_Templatelexer
         }
 
         do {
-            if (preg_match($this->yy_global_pattern2, $this->data, $yymatches, null, $this->counter)) {
+            if (preg_match($this->yy_global_pattern2, $this->data, $yymatches, 0, $this->counter)) {
                 if (!isset($yymatches[ 0 ][ 1 ])) {
                     $yymatches = preg_grep("/(.|\s)+/", $yymatches);
                 } else {
@@ -587,7 +587,7 @@ class Smarty_Internal_Templatelexer
         }
 
         do {
-            if (preg_match($this->yy_global_pattern3, $this->data, $yymatches, null, $this->counter)) {
+            if (preg_match($this->yy_global_pattern3, $this->data, $yymatches, 0, $this->counter)) {
                 if (!isset($yymatches[ 0 ][ 1 ])) {
                     $yymatches = preg_grep("/(.|\s)+/", $yymatches);
                 } else {
@@ -934,7 +934,7 @@ class Smarty_Internal_Templatelexer
         }
 
         do {
-            if (preg_match($this->yy_global_pattern4, $this->data, $yymatches, null, $this->counter)) {
+            if (preg_match($this->yy_global_pattern4, $this->data, $yymatches, 0, $this->counter)) {
                 if (!isset($yymatches[ 0 ][ 1 ])) {
                     $yymatches = preg_grep("/(.|\s)+/", $yymatches);
                 } else {
@@ -1028,7 +1028,7 @@ class Smarty_Internal_Templatelexer
         }
 
         do {
-            if (preg_match($this->yy_global_pattern5, $this->data, $yymatches, null, $this->counter)) {
+            if (preg_match($this->yy_global_pattern5, $this->data, $yymatches, 0, $this->counter)) {
                 if (!isset($yymatches[ 0 ][ 1 ])) {
                     $yymatches = preg_grep("/(.|\s)+/", $yymatches);
                 } else {


### PR DESCRIPTION
hhvm croaks if preg_match is called with `null` as flags-parameter, because it expects a numerical value. Replacing `null` with `0` in the calls to preg_match that violate this expectation allows smarty to be used under hhvm; we have a mixed setup, running under php-fpm as well as under hhvm on the commandline for tools needing the extra performance and generally saner behaviour of hhvm.

````
Fatal error: Uncaught exception 'ErrorException' with message 'preg_match() expects parameter 4 to be integer, null given' in includes/libs/smarty/3.1.31/sysplugins/smarty_internal_templatelexer.php:310
````

I would be pleased if you would consider incorporating this small fix, or educate me if my fix is violating some standard or good-practice I am unaware of.

Many thanks for the great work on smarty -- it is much appreciated.