### PR TITLE
Fix writeFile() mkdir() race condition

### DIFF
--- a/libs/sysplugins/smarty_internal_runtime_writefile.php
+++ b/libs/sysplugins/smarty_internal_runtime_writefile.php
@@ -38,8 +38,8 @@ class Smarty_Internal_Runtime_WriteFile
 
         $_dirpath = dirname($_filepath);
 
-       // if subdirs, create dir structure
-        if ($_dirpath !== '.' && !@mkdir($_dirpath, $_dir_perms, true) && !is_dir($_dirpath)) {
+        // if subdirs, create dir structure
+        if ($_dirpath !== '.' && !@self::ensureDirectoryExists($_dirpath, $_dir_perms)) {
             error_reporting($_error_reporting);
             throw new SmartyException("unable to create directory {$_dirpath}");
         }
@@ -89,5 +89,27 @@ class Smarty_Internal_Runtime_WriteFile
         error_reporting($_error_reporting);
 
         return true;
+    }
+
+    /**
+     * Recursively creates the missing parts of a directory path in a manner that is concurrency-safe.
+     *
+     * @see https://bugs.php.net/bug.php?id=35326
+     *
+     * @param string $pathname a (nested) directory path to create
+     * @param integer $mode the permission to use
+     * @return bool true iff the directory path was successfully created
+     */
+    private static function ensureDirectoryExists($pathname, $mode)
+    {
+        $path_segments = explode(DIRECTORY_SEPARATOR, $pathname);
+
+        $current_pathname = '';
+        foreach ($path_segments as $path_segment) {
+            $current_pathname = $current_pathname . $path_segment . DIRECTORY_SEPARATOR;
+            @mkdir($current_pathname, $mode);
+        }
+
+        return is_dir($pathname);
     }
 }


### PR DESCRIPTION
PHP's `mkdir()` is not concurrency-safe when the `$recursive` flag is enabled. When multiple concurrent processes try to create paths within the same directory structure, interleaving execution of `mkdir()` may cause some of those processes to fail if another process creates a subdirectory they were just about to create. Please see  https://bugs.php.net/bug.php?id=35326 for detailed discussion.

This race condition may cause Smarty template compilation to fail randomly when not all templates have been initialized. Lately, we've observed this problem with increasing frequency in https://github.com/shopware/shopware.

@a-shpota has added code that detects this situation and throws a more meaningful message in 6768340a970beb67422d67e9c885aa226ef95a06. Unfortunately, template compilation will still fail even with these changes applied.

This PR adds a concurrency-safe PHP reimplementation of recursive `mkdir()`. Using this implementation, `writeFile()` will not fail anymore in situations that would have triggered the `mkdir()` race condition before.