### PR TITLE
Let `compileAllTemplates` exit with a non-zero status code if max errors is reached

### DIFF
--- a/libs/sysplugins/smarty_internal_method_compilealltemplates.php
+++ b/libs/sysplugins/smarty_internal_method_compilealltemplates.php
@@ -115,7 +115,7 @@ class Smarty_Internal_Method_CompileAllTemplates
                 $_smarty->_clearTemplateCache();
                 if ($max_errors !== null && $_error_count == $max_errors) {
                     echo "\n<br><br>too many errors\n";
-                    exit();
+                    exit(1);
                 }
             }
         }


### PR DESCRIPTION
This facilitates running `compileAllTemplates` as part of a Continuous Integration job.