### PR TITLE
Added optional support for writing the result of output filters to ca…

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -594,6 +594,13 @@ class Smarty extends Smarty_Internal_TemplateBase
                                  'cache_dir'    => 'CacheDir',);
 
     /**
+     * Allows caching of the output filter result
+     * @internal
+     * @var bool
+     */
+    public $allow_caching_output_filters = false;
+
+    /**
      * Initialize new Smarty object
      */
     public function __construct()
@@ -649,6 +656,19 @@ class Smarty extends Smarty_Internal_TemplateBase
         // create source object
         $source = Smarty_Template_Source::load(null, $this, $resource_name);
         return $source->exists;
+    }
+
+    /**
+     * Enables caching of output filters
+     *
+     * @param bool $bool
+     *
+     * @return $this
+     */
+    public function enableOutputFilterCaching($bool=true)
+    {
+        $this->allow_caching_output_filters = $bool;
+        return $this;
     }
 
     /**

--- a/libs/sysplugins/smarty_internal_runtime_updatecache.php
+++ b/libs/sysplugins/smarty_internal_runtime_updatecache.php
@@ -61,7 +61,7 @@ class Smarty_Internal_Runtime_UpdateCache
                 $content .= $cache_parts[ 1 ][ $curr_idx ];
             }
         }
-        if (!$no_output_filter && !$_template->cached->has_nocache_code &&
+        if (!$no_output_filter && (!$_template->cached->has_nocache_code || $_template->smarty->allow_caching_output_filters === true) &&
             (isset($_template->smarty->autoload_filters[ 'output' ]) ||
              isset($_template->smarty->registered_filters[ 'output' ]))
         ) {


### PR DESCRIPTION
I've added the optional support for "Smarty 3.1.31 doesn't cache output filters if template contains {nocache}" https://github.com/smarty-php/smarty/issues/407