### PR TITLE
Using call_user_func_array to allow passing by reference.

### DIFF
--- a/libs/sysplugins/smarty_internal_runtime_filterhandler.php
+++ b/libs/sysplugins/smarty_internal_runtime_filterhandler.php
@@ -60,7 +60,7 @@ class Smarty_Internal_Runtime_FilterHandler
         // loop over registered filters of specified type
         if (!empty($template->smarty->registered_filters[ $type ])) {
             foreach ($template->smarty->registered_filters[ $type ] as $key => $name) {
-                $content = call_user_func_array($template->smarty->registered_filters[ $type ][ $key ], [$content, &$template]);
+                $content = call_user_func_array($template->smarty->registered_filters[ $type ][ $key ], array($content, &$template));
             }
         }
         // return filtered output

--- a/libs/sysplugins/smarty_internal_runtime_filterhandler.php
+++ b/libs/sysplugins/smarty_internal_runtime_filterhandler.php
@@ -60,7 +60,7 @@ class Smarty_Internal_Runtime_FilterHandler
         // loop over registered filters of specified type
         if (!empty($template->smarty->registered_filters[ $type ])) {
             foreach ($template->smarty->registered_filters[ $type ] as $key => $name) {
-                $content = call_user_func($template->smarty->registered_filters[ $type ][ $key ], $content, $template);
+                $content = call_user_func_array($template->smarty->registered_filters[ $type ][ $key ], [$content, &$template]);
             }
         }
         // return filtered output


### PR DESCRIPTION
Using call_user_func it's not possible to pass a variable as reference, while it is being done. This results in warnings being thrown. When switching to call_user_func_array it is possible to pass by reference.

See docs: https://secure.php.net/manual/en/function.call-user-func-array.php and https://secure.php.net/manual/en/function.call-user-func.php