### PR TITLE
Fixes Smarty->compileAllTemplates() which was ignoring its $extension parameter

### DIFF
--- a/libs/sysplugins/smarty_internal_method_compilealltemplates.php
+++ b/libs/sysplugins/smarty_internal_method_compilealltemplates.php
@@ -75,7 +75,7 @@ class Smarty_Internal_Method_CompileAllTemplates
                 if (substr(basename($_fileinfo->getPathname()), 0, 1) === '.' || strpos($_file, '.svn') !== false) {
                     continue;
                 }
-                if (!substr_compare($_file, $extension, -strlen($extension)) === 0) {
+                if (substr_compare($_file, $extension, -strlen($extension)) !== 0) {
                     continue;
                 }
                 if ($_fileinfo->getPath() !== substr($_dir, 0, -1)) {


### PR DESCRIPTION
Fixes #437 