### PR TITLE
separator only between items

### DIFF
--- a/libs/plugins/function.html_checkboxes.php
+++ b/libs/plugins/function.html_checkboxes.php
@@ -171,6 +171,9 @@ function smarty_function_html_checkboxes($params, Smarty_Internal_Template $temp
         }
     }
 
+    // remove 'separator' from last index
+    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);
     } else {

--- a/libs/plugins/function.html_radios.php
+++ b/libs/plugins/function.html_radios.php
@@ -158,6 +158,9 @@ function smarty_function_html_radios($params, Smarty_Internal_Template $template
         }
     }
 
+    // remove 'separator' from last index
+    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);
     } else {


### PR DESCRIPTION
For functions `html_checkboxes` & `html_radios` attribute `$separator`
A seperator should only appear between the items, not just after.

Example of a problem scenario, `separator="</li><li>"` to put each item in a list row, would result in an extra empty row at the end.

If you want the extra separator at the end of your list, put it in the template.