### PR TITLE
html_checkboxes & html_radios separator fix

### DIFF
--- a/libs/plugins/function.html_checkboxes.php
+++ b/libs/plugins/function.html_checkboxes.php
@@ -172,7 +172,7 @@ function smarty_function_html_checkboxes($params, Smarty_Internal_Template $temp
     }
 
     // remove 'separator' from last index
-    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+    $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
 
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);

--- a/libs/plugins/function.html_checkboxes.php
+++ b/libs/plugins/function.html_checkboxes.php
@@ -171,6 +171,9 @@ function smarty_function_html_checkboxes($params, Smarty_Internal_Template $temp
         }
     }
 
+    // remove 'separator' from last index
+    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);
     } else {

--- a/libs/plugins/function.html_checkboxes.php
+++ b/libs/plugins/function.html_checkboxes.php
@@ -172,7 +172,10 @@ function smarty_function_html_checkboxes($params, Smarty_Internal_Template $temp
     }
 
     // remove 'separator' from last index
-    $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
+    if (!empty($separator)) {
+      $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
+    }
+
 
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);

--- a/libs/plugins/function.html_radios.php
+++ b/libs/plugins/function.html_radios.php
@@ -159,7 +159,7 @@ function smarty_function_html_radios($params, Smarty_Internal_Template $template
     }
 
     // remove 'separator' from last index
-    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+    $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
 
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);

--- a/libs/plugins/function.html_radios.php
+++ b/libs/plugins/function.html_radios.php
@@ -158,6 +158,9 @@ function smarty_function_html_radios($params, Smarty_Internal_Template $template
         }
     }
 
+    // remove 'separator' from last index
+    $_html_result[(count($_html_result) - 1)] = rtrim($_html_result[(count($_html_result) - 1)], $separator);
+
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);
     } else {

--- a/libs/plugins/function.html_radios.php
+++ b/libs/plugins/function.html_radios.php
@@ -159,7 +159,9 @@ function smarty_function_html_radios($params, Smarty_Internal_Template $template
     }
 
     // remove 'separator' from last index
-    $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
+    if (!empty($separator)) {
+      $_html_result[(count($_html_result) - 1)] = substr($_html_result[(count($_html_result) - 1)],0,-(strlen($separator)));
+    }
 
     if (!empty($params[ 'assign' ])) {
         $template->assign($params[ 'assign' ], $_html_result);


### PR DESCRIPTION
For functions `html_checkboxes` & `html_radios` attribute `$separator`
A seperator should only appear between the items, not just after.

Example of a problem scenario, `separator="</li><li>"` to put each item in a list row, would result in an extra empty row at the end.

If you want the extra separator at the end of your list, put it in the template.