### PR TITLE
Fix for $smarty.capture.$varhere, issue #478

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_capture.php
+++ b/libs/sysplugins/smarty_internal_compile_capture.php
@@ -45,8 +45,13 @@ class Smarty_Internal_Compile_Capture extends Smarty_Internal_CompileBase
     {
         $tag = trim($parameter[ 0 ], '"\'');
         $name = isset($parameter[ 1 ]) ? $compiler->getId($parameter[ 1 ]) : null;
-        if (!$name) {
-            //$compiler->trigger_template_error("missing or illegal \$smarty.{$tag} name attribute", null, true);
+        if (!$name && isset($parameter[1])) {
+			$query = '/^\$_smarty_tpl->tpl_vars\[\'[0-9a-zA-Z_]*\'\]->value$/';
+			if(preg_match($query, $parameter[1])){
+				return '$_smarty_tpl->smarty->ext->_capture->getBuffer($_smarty_tpl, '.$parameter[1].')';
+			}else{
+				//$compiler->trigger_template_error("missing or illegal \$smarty.{$tag} name attribute", null, true);
+			}
         }
         return '$_smarty_tpl->smarty->ext->_capture->getBuffer($_smarty_tpl'.(isset($name)?", '{$name}')":')');
     }


### PR DESCRIPTION
Adds a very specific regex to let $smarty.capture$somevar to work once again.  It appears to me by the fact that $parameter[1] is $_smarty_tpl->tpl_vars['bar']->value that this was intended to work.