### PR TITLE
Allow empty cache_lifetime, cache_id, compile_id for subtemplates

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_include.php
+++ b/libs/sysplugins/smarty_internal_compile_include.php
@@ -158,21 +158,21 @@ class Smarty_Internal_Compile_Include extends Smarty_Internal_CompileBase
         } else {
             $_new_caching = Smarty::CACHING_LIFETIME_CURRENT;
         }
-        if (isset($_attr[ 'cache_lifetime' ])) {
+        if (!empty($_attr[ 'cache_lifetime' ])) {
             $_cache_lifetime = $_attr[ 'cache_lifetime' ];
             $call_nocache = true;
             $_caching = $_new_caching;
         } else {
             $_cache_lifetime = '$_smarty_tpl->cache_lifetime';
         }
-        if (isset($_attr[ 'cache_id' ])) {
+        if (!empty($_attr[ 'cache_id' ])) {
             $_cache_id = $_attr[ 'cache_id' ];
             $call_nocache = true;
             $_caching = $_new_caching;
         } else {
             $_cache_id = '$_smarty_tpl->cache_id';
         }
-        if (isset($_attr[ 'compile_id' ])) {
+        if (!empty($_attr[ 'compile_id' ])) {
             $_compile_id = $_attr[ 'compile_id' ];
         } else {
             $_compile_id = '$_smarty_tpl->compile_id';


### PR DESCRIPTION
cache_lifetime, cache_id, compile_id for subtemplates should not only be set, but should be not empty for subtemplate caching to be enabled. 

At the moment even if cache_id is provided as false or null, the subtemplate caching is turned on for the template. This leads to a bloated code like:
{if $cacheId = getSomeDynamicCacheId($someFactor)}
    {include file="my.tpl" cache_id=$cacheId}
{else}
    {include file="my.tpl"}
{/if}

With this change this would be done as:
{include file="my.tpl" cache_id=getSomeDynamicCacheId($someFactor)}

So caching won't be turned on if that getSomeDynamicCacheId would return false or null.
