### PR TITLE
Use Composer autoloader instead of Smarty_Autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "php": ">=5.2"
     },
     "autoload": {
-        "files": [
-            "libs/bootstrap.php"
+        "classmap": [
+            "libs"
         ]
     },
     "extra": {


### PR DESCRIPTION
All you have to do is change `composer.json`, which won't make Composer autoload `bootstrap.php` anymore, but make a classmap instead.