### PR TITLE
Bump php versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ services:
   - mysql
 
 before_script:
-    - if [ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]; then travis_retry composer --prefer-source --dev install; fi
-    - if [ ${TRAVIS_PHP_VERSION:0:3} <= "5.6" ]; then  phpenv config-add travis.ini; fi
-    - if [ ${TRAVIS_PHP_VERSION:0:3} >= "5.3" ]; then  phpenv config-add error_reporting.ini; fi
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then  composer require phpunit/phpunit 6.4.1; fi
     - mysql -e "create database IF NOT EXISTS test;" -uroot
 
 before_install:
@@ -38,10 +34,4 @@ install:
 
 script:
    - cd smarty-phpunit
-   - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then
-        ../vendor/bin/phpunit ./;
-    else
-        phpunit ./;
-    fi
-
-
+   - ../vendor/bin/phpunit ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,13 @@ matrix:
    - php: 7.0
    - php: 7.1
    - php: 7.2
+   - php: 7.3
+   - php: 7.4snapshot
+   - php: nightly
   fast_finish: true
+  allow_failures:
+   - php: 7.4snapshot
+   - php: nightly
 
 services:
   - memcached

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,6 @@
         }
     },
     "require-dev": {
-        "smarty/smarty-dev": "~3.1@dev"
+        "phpunit/phpunit": "^6.4.1|^7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4.1|^7.0"
+        "phpunit/phpunit": "^6.4.1"
     }
 }


### PR DESCRIPTION
This fixes the travis build by removing the direct `composer require` statement for PHPUnit (not sure why, but this would cause composer conflicts, but having the dependency in `require-dev` was fine (I assume this is because the `composer require` call was loading phpunit 6.4.1 exactly, but when it's defined as `^6.4.1` the latest 6.x version is installed, which doesn't have the same dep problems)).

https://travis-ci.org/jaydiablo/smarty/builds/495108543

Also removing some old travis PHP version check statements as the 5.x versions of PHP aren't in the build matrix, so they'd never evaluate to true.

Adding php 7.3, 7.4snapshot (can fail) and nightly (which is php 8.0, can fail) to the build matrix.

I'm not clear why smarty (dev) was being required in the `require-dev` block, it was causing my travis build to fail though, so I removed it:

https://travis-ci.org/jaydiablo/smarty/jobs/495098719

FYI, I did try allowing PHPUnit 7.0 (as `"^6.4.1|^7.0"`), but PHPUnit 7.5 (perhaps earlier) changed the way it evaluates some numerical strings (`012345` is not the same as `12345`), as seen in this build:

https://travis-ci.org/jaydiablo/smarty/jobs/495105712

That's something that would need to be fixed in the `smarty-phpunit` project though.