### PR TITLE
exclude error_reporting.ini from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 *.y   text eol=lf
 *.lex text eol=lf
 
-
 # exclude from git export
 /travis.ini export-ignore
 /myconfig.ini export-ignore
@@ -14,3 +13,4 @@
 /.gitattributes export-ignore
 /lexer/ export-ignore
 /utilities/ export-ignore
+/error_reporting.ini export-ignore


### PR DESCRIPTION
used only for travis testing. the file was added in 19ebab9e4a73b643e7bd137905a6e4e7025289c1