### PR TITLE
Fixing problem with assigning value to object variables as arrays in smarty_internal_compile_assign

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_assign.php
+++ b/libs/sysplugins/smarty_internal_compile_assign.php
@@ -83,7 +83,7 @@ class Smarty_Internal_Compile_Assign extends Smarty_Internal_CompileBase
         if (isset($parameter[ 'smarty_internal_index' ])) {
             $output =
                 "<?php \$_tmp_array = isset(\$_smarty_tpl->tpl_vars[{$_var}]) ? \$_smarty_tpl->tpl_vars[{$_var}]->value : array();\n";
-            $output .= "if (!is_array(\$_tmp_array) || \$_tmp_array instanceof ArrayAccess) {\n";
+            $output .= "if (!(is_array(\$_tmp_array) || \$_tmp_array instanceof ArrayAccess)) {\n";
             $output .= "settype(\$_tmp_array, 'array');\n";
             $output .= "}\n";
             $output .= "\$_tmp_array{$parameter['smarty_internal_index']} = {$_attr['value']};\n";


### PR DESCRIPTION
There was a problem when trying to assign a value to an object, as if it were an array

(using 42 as a placeholder)
```smarty
{$model.foo=42}
```

`$model` is an object, implementing the ArrayAccess interface, therefore it's usable as an array

Still, Smarty_Internal_Compile_Assign compiled that code like this:
```php
$_tmp_array = isset($_smarty_tpl->tpl_vars['model']) ? $_smarty_tpl->tpl_vars['model']->value : array(); // If variable exists, use that, otherwise use a brand new array
if (!is_array($_tmp_array) || $_tmp_array instanceof ArrayAccess) { // <-- Either wrong operator order or messed up De Morgan's law
settype($_tmp_array, 'array'); // Convert to array
}
$_tmp_array['foo'] = 42; // Assign the value to the key
$_smarty_tpl->_assignInScope('model', $_tmp_array); // Put it back in scope
```

This particular condition is wrong:
```php
!is_array($_tmp_array) || $_tmp_array instanceof ArrayAccess
```
If it's not an array, it won't check if it's usable as array (instanceof ArrayAccess)
If it's an array, it'll unnecessarily check if it's otherwise usable as one (it'll fail, since arrays are not instanceof ArrayAccess, but that conversion even if happened wouldn't be a problem, since it already is an array)

The correct condition should be `if it's neither an array, nor usable as one, then convert`