### PR TITLE
Fixed using wrong get and set methods from class memcached

### DIFF
--- a/demo/plugins/cacheresource.memcache.php
+++ b/demo/plugins/cacheresource.memcache.php
@@ -42,18 +42,12 @@ class Smarty_CacheResource_Memcache extends Smarty_CacheResource_KeyValueStore
      */
     protected function read(array $keys)
     {
-        $_keys = $lookup = array();
-        foreach ($keys as $k) {
-            $_k = sha1($k);
-            $_keys[] = $_k;
-            $lookup[ $_k ] = $k;
+        $res = array();
+        foreach ($keys as $key) {
+            $k = sha1($key);
+            $res[$key] = $this->memcache->get($k);
         }
-        $_res = array();
-        $res = $this->memcache->get($_keys);
-        foreach ($res as $k => $v) {
-            $_res[ $lookup[ $k ] ] = $v;
-        }
-        return $_res;
+        return $res;
     }
 
     /**
@@ -68,7 +62,11 @@ class Smarty_CacheResource_Memcache extends Smarty_CacheResource_KeyValueStore
     {
         foreach ($keys as $k => $v) {
             $k = sha1($k);
-            $this->memcache->set($k, $v, 0, $expire);
+            if (class_exists('Memcached')) {
+                $this->memcache->set($k, $v, $expire);
+            } else {
+                $this->memcache->set($k, $v, 0, $expire);
+            }
         }
         return true;
     }


### PR DESCRIPTION
The set and get method of class memcached needs different parameters than class memcache. Therefore, it must be changed.

Memcached::get(string $key); can only get one value
Memcached::set (string $key , mixed $value , int $expiration); have only three parameters