### PR TITLE
allow StdClass to be cast to array when compiling foreach, to prevent invalid count warning in PHP 7.2+

### DIFF
--- a/libs/Smarty_Compiler.class.php
+++ b/libs/Smarty_Compiler.class.php
@@ -1192,7 +1192,7 @@ class Smarty_Compiler extends Smarty {
         }
 
         $output = '<?php ';
-        $output .= "\$_from = $from; if (!is_array(\$_from) && !is_object(\$_from)) { settype(\$_from, 'array'); }";
+        $output .= "\$_from = $from; if ((\$_from instanceof StdClass) || (!is_array(\$_from) && !is_object(\$_from))) { settype(\$_from, 'array'); }";
         if (isset($name)) {
             $foreach_props = "\$this->_foreach[$name]";
             $output .= "{$foreach_props} = array('total' => count(\$_from), 'iteration' => 0);\n";


### PR DESCRIPTION
Calling Smarty 2.x foreach on an StdClass parameter, triggers a warning on PHP 7.2+ 
StdClass is commonly present after deserialising an object via json_decode/unserialize.
Historically this has worked fine in Smarty 2.x, without the StdClass having to be cast to an array first, but now triggers a warning on PHP 7.2+

This commits just adds an edge case to explicitly cast StdClass to an array, to prevent the warning but also without breaking support for previous PHP versions.

Note that PHP 5 introduced the Countable interface, which looked like a tempting solution.
But even in PHP 7.2+, StdClass returns false for `instanceof Countable` so is not usable anyway

Would be grateful to see this merged into 2.x branch.
