### PR TITLE
Add Travis badge and php compatibility infos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Smarty 3 template engine
 [smarty.net](https://www.smarty.net/) 
 
+[![Build Status](https://travis-ci.org/smarty-php/smarty.svg?branch=master)](https://travis-ci.org/smarty-php/smarty)
+
 ## Documentation
 
 For documentation see 
 [www.smarty.net/docs/en/](https://www.smarty.net/docs/en/) 
+
+## Requirements
+
+Smarty can be run with PHP 5.2 to PHP 7.4.
 
 ## Distribution repository
 


### PR DESCRIPTION
Hi ! I wanted to make sure Smarty is compatible with php7.3 and php7.4 and it was not obvious at 1st glance. So I suggest the following enhancements to help other people with the same question.