### PR TITLE
Allow/Deny inline constants

### DIFF
--- a/lexer/smarty_internal_templateparser.y
+++ b/lexer/smarty_internal_templateparser.y
@@ -154,6 +154,7 @@ class Smarty_Internal_Templateparser
         $this->template = $this->compiler->template;
         $this->smarty = $this->template->smarty;
         $this->security = isset($this->smarty->security_policy) ? $this->smarty->security_policy : false;
+        $this->allow_inline_constants = $this->smarty->allow_inline_constants;
         $this->current_buffer = $this->root_buffer = new Smarty_Internal_ParseTree_Template();
     }
 
@@ -310,7 +311,7 @@ smartytag(A)::= SIMPLETAG(B). {
         $this->strip = true;
         A = null;;
     } else {
-        if (defined($tag)) {
+        if ($this->allow_inline_constants AND defined($tag)) {
             if ($this->security) {
                $this->security->isTrustedConstant($tag, $this->compiler);
             }
@@ -381,7 +382,7 @@ output(A) ::= expr(B). {
 
                   // tag with optional Smarty2 style attributes
 tag(res)   ::= LDEL ID(i) attributes(a). {
-        if (defined(i)) {
+        if ($this->allow_inline_constants AND defined(i)) {
             if ($this->security) {
                 $this->security->isTrustedConstant(i, $this->compiler);
             }
@@ -391,7 +392,7 @@ tag(res)   ::= LDEL ID(i) attributes(a). {
         }
 }
 tag(res)   ::= LDEL ID(i). {
-        if (defined(i)) {
+        if ($this->allow_inline_constants AND defined(i)) {
             if ($this->security) {
                 $this->security->isTrustedConstant(i, $this->compiler);
             }
@@ -404,7 +405,7 @@ tag(res)   ::= LDEL ID(i). {
 
                   // tag with modifier and optional Smarty2 style attributes
 tag(res)   ::= LDEL ID(i) modifierlist(l)attributes(a). {
-        if (defined(i)) {
+        if ($this->allow_inline_constants AND defined(i)) {
             if ($this->security) {
                 $this->security->isTrustedConstant(i, $this->compiler);
             }
@@ -541,7 +542,7 @@ attributes(res)  ::= . {
                   
                   // attribute
 attribute(res)   ::= SPACE ID(v) EQUAL ID(id). {
-    if (defined(id)) {
+    if ($this->allow_inline_constants AND defined(id)) {
         if ($this->security) {
             $this->security->isTrustedConstant(id, $this->compiler);
         }
@@ -713,7 +714,7 @@ value(res)       ::= DOT INTEGER(n1). {
 
                  // ID, true, false, null
 value(res)       ::= ID(id). {
-    if (defined(id)) {
+    if ($this->allow_inline_constants AND defined(id)) {
         if ($this->security) {
              $this->security->isTrustedConstant(id, $this->compiler);
         }

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -112,7 +112,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.36';
+    const SMARTY_VERSION = '3.1.37-dev-1';
     /**
      * define variable scopes
      */
@@ -309,6 +309,14 @@ class Smarty extends Smarty_Internal_TemplateBase
      * @var boolean
      */
     public $allow_ambiguous_resources = false;
+
+    /**
+     * allow inline constants (use defined constants without the $smarty.const. prefix)
+     * default to true for backwards compatibility
+     *
+     * @var boolean
+     */
+    public $allow_inline_constants = true;
 
     /**
      * merge compiled includes

--- a/libs/sysplugins/smarty_internal_templateparser.php
+++ b/libs/sysplugins/smarty_internal_templateparser.php
@@ -1771,6 +1771,7 @@ class Smarty_Internal_Templateparser
         $this->template = $this->compiler->template;
         $this->smarty = $this->template->smarty;
         $this->security = isset($this->smarty->security_policy) ? $this->smarty->security_policy : false;
+        $this->allow_inline_constants = $this->smarty->allow_inline_constants;
         $this->current_buffer = $this->root_buffer = new Smarty_Internal_ParseTree_Template();
     }  /* The parser's stack */
     public static function yy_destructor($yymajor, $yypminor)
@@ -2259,7 +2260,7 @@ class Smarty_Internal_Templateparser
             $this->strip = true;
             $this->_retvalue = null;
         } else {
-            if (defined($tag)) {
+            if ($this->allow_inline_constants AND defined($tag)) {
                 if ($this->security) {
                     $this->security->isTrustedConstant($tag, $this->compiler);
                 }
@@ -2348,7 +2349,7 @@ class Smarty_Internal_Templateparser
     // line 393 "../smarty/lexer/smarty_internal_templateparser.y"
     public function yy_r25()
     {
-        if (defined($this->yystack[ $this->yyidx + -1 ]->minor)) {
+        if ($this->allow_inline_constants AND defined($this->yystack[ $this->yyidx + -1 ]->minor)) {
             if ($this->security) {
                 $this->security->isTrustedConstant($this->yystack[ $this->yyidx + -1 ]->minor, $this->compiler);
             }
@@ -2365,7 +2366,7 @@ class Smarty_Internal_Templateparser
     // line 406 "../smarty/lexer/smarty_internal_templateparser.y"
     public function yy_r26()
     {
-        if (defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
+        if ($this->allow_inline_constants AND defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
             if ($this->security) {
                 $this->security->isTrustedConstant($this->yystack[ $this->yyidx + 0 ]->minor, $this->compiler);
             }
@@ -2380,7 +2381,7 @@ class Smarty_Internal_Templateparser
     // line 418 "../smarty/lexer/smarty_internal_templateparser.y"
     public function yy_r27()
     {
-        if (defined($this->yystack[ $this->yyidx + -2 ]->minor)) {
+        if ($this->allow_inline_constants AND defined($this->yystack[ $this->yyidx + -2 ]->minor)) {
             if ($this->security) {
                 $this->security->isTrustedConstant($this->yystack[ $this->yyidx + -2 ]->minor, $this->compiler);
             }
@@ -2614,7 +2615,7 @@ class Smarty_Internal_Templateparser
     // line 554 "../smarty/lexer/smarty_internal_templateparser.y"
     public function yy_r53()
     {
-        if (defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
+        if ($this->allow_inline_constants AND defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
             if ($this->security) {
                 $this->security->isTrustedConstant($this->yystack[ $this->yyidx + 0 ]->minor, $this->compiler);
             }
@@ -2809,7 +2810,7 @@ class Smarty_Internal_Templateparser
     // line 732 "../smarty/lexer/smarty_internal_templateparser.y"
     public function yy_r88()
     {
-        if (defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
+        if ($this->allow_inline_constants AND defined($this->yystack[ $this->yyidx + 0 ]->minor)) {
             if ($this->security) {
                 $this->security->isTrustedConstant($this->yystack[ $this->yyidx + 0 ]->minor, $this->compiler);
             }


### PR DESCRIPTION
Adding var `$allow_inline_constants` to SmartyClass and using it in templateparser. This way you can globally deny use of inline constants without `$smarty.const.` prefix to avoid various ambiguities. Just set `$Smarty->allow_inline_constants = false`. Defaults to true for backwards compatibility.
Closes #554