### PR TITLE
Bumped phpdoc @version tag to 3.1.36

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -27,7 +27,7 @@
  * @author    Uwe Tews   <uwe dot tews at gmail dot com>
  * @author    Rodney Rehm
  * @package   Smarty
- * @version   3.1.34-dev
+ * @version   3.1.36
  */
 /**
  * set SMARTY_DIR to absolute path to Smarty library files.


### PR DESCRIPTION
Although this could be removed, but because the header comment is still there, it's a good idea to keep the @version tag up-to-date with the current working version in order to avoid confusion for those who still read it :)