### PR TITLE
Updates Ubuntu from Trusty to Xenial on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: php
+os: linux
+dist: xenial
 
-sudo: false
-
-dist: trusty
-
-matrix:
+jobs:
   include:
    - php: 5.3 # Composer requires PHP 5.3.2+ to run, so we cannot test below 5.3
      dist: precise # PHP 5.3 is supported only on Precise.
    - php: 5.4
+     dist: trusty  # PHP 5.4 is supported only on Trusty.
    - php: 5.5
+     dist: trusty  # PHP 5.5 is supported only on Trusty.
    - php: 5.6
    - php: 7.0
    - php: 7.1


### PR DESCRIPTION
By updating to Xenial, we can test in latest php version.
For example, Trusty using php7.4.0 for php7.4 (ADD: php7.4.7 in Xenial) as
https://travis-ci.org/github/smarty-php/smarty/jobs/683366557#L445

Additionally, this commit fixes config warning
https://travis-ci.org/github/smarty-php/smarty/jobs/683366557/config