### PR TITLE
Set $errcontext argument optional to support PHP 8

### DIFF
--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -65,7 +65,7 @@ class Smarty_Internal_ErrorHandler
      *
      * @return bool
      */
-    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $_is_muted_directory = false;
         // add the SMARTY_DIR to the list of muted directories


### PR DESCRIPTION
- Argument is optional and deprecated in PHP 7.2