### PR TITLE
plugins: shared: mb_str_replace: mb_split special case fix

### DIFF
--- a/libs/plugins/shared.mb_str_replace.php
+++ b/libs/plugins/shared.mb_str_replace.php
@@ -45,6 +45,9 @@ if (!function_exists('smarty_mb_str_replace')) {
             }
         } else {
             $parts = mb_split(preg_quote($search), $subject);
+            if (!is_array($parts)) {
+                $parts = array();
+            }
             $count = count($parts) - 1;
             $subject = implode($replace, $parts);
         }


### PR DESCRIPTION
`mb_split` might return false, and following call to `count` throws a `TypeError` in PHP 8 if supplied argument is not of type Countable|array