### PR TITLE
plugins: escape: javascript escaping secure fix

### DIFF
--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -184,7 +184,11 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
                     '"'  => '\\"',
                     "\r" => '\\r',
                     "\n" => '\\n',
-                    '</' => '<\/'
+                    '</' => '<\/',
+                    // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+                    '<!--' => '<\!--',
+                    '<s'   => '<\s',
+                    '<S'   => '<\S'
                 )
             );
         case 'mail':

--- a/libs/plugins/modifiercompiler.escape.php
+++ b/libs/plugins/modifiercompiler.escape.php
@@ -89,9 +89,10 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 return 'preg_replace("%(?<!\\\\\\\\)\'%", "\\\'",' . $params[ 0 ] . ')';
             case 'javascript':
                 // escape quotes and backslashes, newlines, etc.
+                // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
                 return 'strtr(' .
                        $params[ 0 ] .
-                       ', array("\\\\" => "\\\\\\\\", "\'" => "\\\\\'", "\"" => "\\\\\"", "\\r" => "\\\\r", "\\n" => "\\\n", "</" => "<\/" ))';
+                       ', array("\\\\" => "\\\\\\\\", "\'" => "\\\\\'", "\"" => "\\\\\"", "\\r" => "\\\\r", "\\n" => "\\\n", "</" => "<\/", "<!--" => "<\!--", "<s" => "<\s", "<S" => "<\S" ))';
         }
     } catch (SmartyException $e) {
         // pass through to regular plugin fallback


### PR DESCRIPTION
There are poor escaping for javascript now. See https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements for details.

## Code for reproduction
_test.php_
```
<?php
require_once('libs/Smarty.class.php');
$smarty = new Smarty();
$smarty->force_compile = true;
$smarty->caching = false;

$smarty->assign('name', "\abc\r\n\"'</script></Script></scripT><!--<script><Script><scripT>");
$smarty->display('test.tpl');
```

_test.tpl_
```
<script>
	// if (x<!--y)
	console.log('{$name|escape:'javascript'}')
	console.log('next output')
</script>

<script>
	console.log("{$name|escape:'javascript'}")
	// if ( player<script )
	console.log('next output')
</script>

<script>
	console.log('next output')
</script>
```
## Expected output in browser console:
```
\abc
"'</script></<Script></scripT><!--<script><<Script><scripT>
next output
\abc
"'</script></<Script></scripT><!--<script><<Script><scripT>
next output
next output
```

## Actual (without this fix) output in browser console:
```
```