### PR TITLE
A new option for smarty config: $smarty->outputMinify(true) to result minified html code (what do now the {strip} tpl wrapper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- modifier escape now triggers a E_USER_NOTICE when an unsupported escape type is used https://github.com/smarty-php/smarty/pull/649
+
 ## [3.1.39] - 2021-02-17
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
-- Prevent access to `$smarty.template_object` in Security mode
-- Code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
+- Prevent access to `$smarty.template_object` in sandbox mode
+- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
 
 ## [3.1.38] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Prevent access to `$smarty.template_object` in Security mode
+
 ## [3.1.38] - 2021-01-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Prevent access to `$smarty.template_object` in Security mode
+- Code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
 
 ## [3.1.38] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.39] - 2021-02-17
+
 ### Security
 - Prevent access to `$smarty.template_object` in sandbox mode
 - Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.39] - 2021-02-17
 
 ### Security
-- Prevent access to `$smarty.template_object` in sandbox mode
-- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
+- Prevent access to `$smarty.template_object` in sandbox mode. This addresses CVE-2021-26119.
+- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}`. This addresses CVE-2021-26120.
 
 ## [3.1.38] - 2021-01-08
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Smarty can be run with PHP 5.2 to PHP 7.4.
 
 > Read the NEW_FEATURES and INHERITANCE_RELEASE_NOTES file for recent extensions to Smarty 3.1 functionality
 
-Smarty versions 3.1.11 or later are now on github and can be installed with Composer.
+Smarty versions 3.1.11 or later are now on GitHub and can be installed with Composer.
 
 
 The "smarty/smarty" package will start at libs/....   subfolder.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Smarty currently supports the latest minor version of Smarty 3 and Smarty 4. (Smarty 4 has not been released yet.)
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.0.x   | :white_check_mark: |
+| 3.1.x   | :white_check_mark: |
+| < 3.1   | :x:                |
+
+## Reporting a Vulnerability
+
+ If you have discovered a security issue with Smarty, please contact us at mail [at] simonwisselink.nl. Do not 
+ disclose your findings publicly and PLEASE PLEASE do not file an Issue.
+ 
+We will try to confirm the vulnerability and develop a fix if appropriate. When we release the fix, we will publish 
+a security release. Please let us know if you want to be credited.

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -111,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.38';
+    const SMARTY_VERSION = '3.1.39';
     /**
      * define variable scopes
      */

--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -250,6 +250,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
             }
             return $return;
         default:
+            trigger_error("escape: unsupported type: $esc_type - returning unmodified string", E_USER_NOTICE);
             return $string;
     }
 }

--- a/libs/sysplugins/smarty_internal_compile_function.php
+++ b/libs/sysplugins/smarty_internal_compile_function.php
@@ -58,6 +58,11 @@ class Smarty_Internal_Compile_Function extends Smarty_Internal_CompileBase
         }
         unset($_attr[ 'nocache' ]);
         $_name = trim($_attr[ 'name' ], '\'"');
+
+        if (!preg_match('/^[a-zA-Z0-9_\x80-\xff]+$/', $_name)) {
+	        $compiler->trigger_template_error("Function name contains invalid characters: {$_name}", null, true);
+        }
+
         $compiler->parent_compiler->tpl_function[ $_name ] = array();
         $save = array(
             $_attr, $compiler->parser->current_buffer, $compiler->template->compiled->has_nocache_code,

--- a/libs/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/libs/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -81,6 +81,10 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                 case 'template':
                     return 'basename($_smarty_tpl->source->filepath)';
                 case 'template_object':
+                    if (isset($compiler->smarty->security_policy)) {
+                        $compiler->trigger_template_error("(secure mode) template_object not permitted");
+                        break;
+                    }
                     return '$_smarty_tpl';
                 case 'current_dir':
                     return 'dirname($_smarty_tpl->source->filepath)';

--- a/make-release.sh
+++ b/make-release.sh
@@ -14,6 +14,6 @@ git pull
 git merge --no-ff "release/$1"
 git branch -d "release/$1"
 git tag -a "v$1" -m "Release $1"
-git push --follow-tags
 
 printf 'Done creating release %s\n' "$1"
+printf 'Run `git push --follow-tags origin` to publish it.\n'

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -382,6 +382,15 @@ class SecurityTest extends PHPUnit_Smarty
         $this->smarty->security_policy->trusted_uri = array();
         $this->assertContains('<title>Preface | Smarty</title>', $this->smarty->fetch('string:{fetch file="https://www.smarty.net/docs/en/preface.tpl"}'));
     }
+
+    /**
+     * In security mode, accessing $smarty.template_object should be illegal.
+     * @expectedException SmartyCompilerException
+     */
+    public function testSmartyTemplateObject() {
+        $this->smarty->display('string:{$smarty.template_object}');
+    }
+
 }
 
 class mysecuritystaticclass

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -431,5 +431,14 @@ class CompileFunctionTest extends PHPUnit_Smarty
                      array("{function name=simple}A{\$foo}\nC{/function}{call name='simple'}", "Abar\nC", 'T14', $i++),
                      array("{function name=simple}A\n{\$foo}\nC{/function}{call name='simple'}", "A\nbar\nC", 'T15', $i++),
         );
-            }
+    }
+
+    /**
+     * Test handling of function names that are a security risk
+     * @expectedException        SmartyCompilerException
+     */
+    public function testIllegalFunctionName() {
+	    $this->smarty->fetch('string:{function name=\'rce(){};echo "hi";function \'}{/function}');
+    }
+
 }


### PR DESCRIPTION
Instead to use {strip} wrapper in each template to dispaly a minified html code, will be nice to have something like:
"$smarty->outputMinify(true);"


In config to can write:
```
define('DEBUG', true);
$smarty->outputMinify(DEBUG ? true : false);
```
It's very hard now to switch between minified and normal code source (html) !
