### PR TITLE
Optimize away two stat calls per template request

### DIFF
--- a/libs/sysplugins/smarty_internal_resource_file.php
+++ b/libs/sysplugins/smarty_internal_resource_file.php
@@ -73,7 +73,7 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      */
     public function getContent(Smarty_Template_Source $source)
     {
-        if (($source->smarty->compile_check && $source->exists)
+        if (($source->smarty->compile_check && !$source->exists)
             || false === ($content = file_get_contents($source->filepath))
         ) {
             throw new SmartyException(

--- a/libs/sysplugins/smarty_template_compiled.php
+++ b/libs/sysplugins/smarty_template_compiled.php
@@ -74,9 +74,14 @@ class Smarty_Template_Compiled extends Smarty_Template_Resource_Base
             $this->filepath .= '.cache';
         }
         $this->filepath .= '.php';
-        $this->timestamp = $this->exists = is_file($this->filepath);
-        if ($this->exists) {
-            $this->timestamp = filemtime($this->filepath);
+
+        if ($smarty->compile_check) {
+            $this->timestamp = $this->exists = is_file($this->filepath);
+            if ($this->exists) {
+                $this->timestamp = filemtime($this->filepath);
+            }
+        } else {
+            $this->timestamp = $this->exists = true;
         }
     }
 
@@ -135,8 +140,9 @@ class Smarty_Template_Compiled extends Smarty_Template_Resource_Base
         if ($source->handler->recompiled) {
             $source->handler->process($_smarty_tpl);
         } elseif (!$source->handler->uncompiled) {
-            if (!$this->exists || $smarty->force_compile
-                || ($_smarty_tpl->compile_check && $source->getTimeStamp() > $this->getTimeStamp())
+            if (
+                $smarty->force_compile ||
+                ($_smarty_tpl->compile_check && (!$this->exists || ($source->getTimeStamp() > $this->getTimeStamp())))
             ) {
                 $this->compileTemplateSource($_smarty_tpl);
                 $compileCheck = $_smarty_tpl->compile_check;


### PR DESCRIPTION
…assuming the source template exists. Note that this implementation disables support for the fallback to templates relative to getcwd() if a template is not found in the specified template dirs, so it might be better to release this as a new version, or to add an alternative resource for this.