### PR TITLE
Naive attempt at stopping incorrect escape type being used

### DIFF
--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -250,6 +250,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
             }
             return $return;
         default:
+            trigger_error("escape: unsupported type: $esc_type - returning unmodified string", E_USER_NOTICE);
             return $string;
     }
 }


### PR DESCRIPTION
I have found myself doing "....|escape:html_attr" or" ....|escape:quote" a few times. It'd help if there was some sort of warning logged if an unsupported escape type is used. 