### PR TITLE
Append target file ext/name to tmp file (speedup antivirus scans)

### DIFF
--- a/libs/sysplugins/smarty_internal_runtime_writefile.php
+++ b/libs/sysplugins/smarty_internal_runtime_writefile.php
@@ -54,7 +54,10 @@ class Smarty_Internal_Runtime_WriteFile
             }
         }
         // write to tmp file, then move to overt file lock race condition
-        $_tmp_file = $_dirpath . DIRECTORY_SEPARATOR . str_replace(array('.', ','), '_', uniqid('wrt', true));
+        // use the original file extension/basename to prevent extensive file scans
+        // by antiviruses like Microsoft Defender
+        $_tmp_file = $_dirpath . DIRECTORY_SEPARATOR . '.' . str_replace(array('.', ','), '_', uniqid('wrt', true))
+            . '.' . basename($_filepath);
         if (!file_put_contents($_tmp_file, $_contents)) {
             error_reporting($_error_reporting);
             throw new SmartyException("unable to write file {$_tmp_file}");


### PR DESCRIPTION
No file extension causes issues with Microsoft Antivirus, this simple update increase performance about 5x.

Was super hard to debug, but once ".php" suffix is added, performance is fixed consistently on Windows.

A bugfix release should be done once merged.