### PR TITLE
Add PHP 8.1 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
         compiler:
           - default

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -169,6 +169,11 @@ class Smarty extends Smarty_Internal_TemplateBase
     public static $_DATE_FORMAT = '%b %e, %Y';
 
     /**
+     * The date format to be used internally by IntlDateFormatter
+     */
+    public static $_ICU_DATE_FORMAT = 'MMM d, yyyy';
+
+    /**
      * Flag denoting if PCRE should run in UTF-8 mode
      */
     public static $_UTF8_MODIFIER = 'u';

--- a/libs/plugins/modifier.date_format_intl.php
+++ b/libs/plugins/modifier.date_format_intl.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty date_format_intl modifier plugin
+ * Type:     modifier
+ * Name:     date_format_intl
+ * Purpose:  format datestamps via IntlDateFormatter
+ * Input:
+ *          - string: input date string
+ *          - format: ICU format for output
+ *          - default_date: default date if $string is empty
+ *
+ * @link   https://www.smarty.net/manual/en/language.modifier.date.format.php date_format (Smarty online manual)
+ * @author Monte Ohrt <monte at ohrt dot com>
+ *
+ * @param string $string       input date string
+ * @param string $format       ICU format for output
+ * @param string $default_date default date if $string is empty
+ *
+ * @return string |void
+ * @uses   smarty_make_timestamp()
+ */
+function smarty_modifier_date_format_intl($string, $format = null, $default_date = '')
+{
+    if ($format === null) {
+        $format = Smarty::$_ICU_DATE_FORMAT;
+    }
+    /**
+     * require_once the {@link shared.make_timestamp.php} plugin
+     */
+    static $is_loaded = false;
+    if (!$is_loaded) {
+        if (!is_callable('smarty_make_timestamp')) {
+            include_once SMARTY_PLUGINS_DIR . 'shared.make_timestamp.php';
+        }
+        $is_loaded = true;
+    }
+    if (!empty($string) && $string !== '0000-00-00' && $string !== '0000-00-00 00:00:00') {
+        $timestamp = smarty_make_timestamp($string);
+    } elseif (!empty($default_date)) {
+        $timestamp = smarty_make_timestamp($default_date);
+    } else {
+        return;
+    }
+    if (!class_exists('IntlDateFormatter')) {
+        return;
+    }
+
+    $formatter = new IntlDateFormatter(
+        setlocale(LC_TIME, '0'),
+        IntlDateFormatter::NONE,
+        IntlDateFormatter::NONE
+    );
+    $formatter->setPattern($format);
+
+    return $formatter->format($timestamp);
+}

--- a/libs/sysplugins/smarty_internal_cacheresource_file.php
+++ b/libs/sysplugins/smarty_internal_cacheresource_file.php
@@ -196,8 +196,8 @@ class Smarty_Internal_CacheResource_File extends Smarty_CacheResource
      */
     public function hasLock(Smarty $smarty, Smarty_Template_Cached $cached)
     {
-        clearstatcache(true, $cached->lock_id);
-        if (is_file($cached->lock_id)) {
+        clearstatcache(true, $cached->lock_id ?? '');
+        if (null !== $cached->lock_id && is_file($cached->lock_id)) {
             $t = filemtime($cached->lock_id);
             return $t && (time() - $t < $smarty->locking_timeout);
         } else {

--- a/libs/sysplugins/smarty_internal_compile_function.php
+++ b/libs/sysplugins/smarty_internal_compile_function.php
@@ -157,7 +157,7 @@ class Smarty_Internal_Compile_Functionclose extends Smarty_Internal_CompileBase
             $output = "<?php echo \"/*%%SmartyNocache:{$compiler->template->compiled->nocache_hash}%%*/<?php ";
             $output .= "\\\$_smarty_tpl->smarty->ext->_tplFunction->restoreTemplateVariables(\\\$_smarty_tpl, '{$_name}');?>\n";
             $output .= "/*/%%SmartyNocache:{$compiler->template->compiled->nocache_hash}%%*/\";\n?>";
-            $output .= "<?php echo str_replace('{$compiler->template->compiled->nocache_hash}', \$_smarty_tpl->compiled->nocache_hash, ob_get_clean());\n";
+            $output .= "<?php echo str_replace('{$compiler->template->compiled->nocache_hash}', \$_smarty_tpl->compiled->nocache_hash ?? '', ob_get_clean());\n";
             $output .= "}\n}\n";
             $output .= "/*/ {$_funcName}_nocache */\n\n";
             $output .= "?>\n";

--- a/libs/sysplugins/smarty_internal_config_file_compiler.php
+++ b/libs/sysplugins/smarty_internal_config_file_compiler.php
@@ -158,7 +158,7 @@ class Smarty_Internal_Config_File_Compiler
         }
         // template header code
         $template_header =
-            "<?php /* Smarty version " . Smarty::SMARTY_VERSION . ", created on " . strftime("%Y-%m-%d %H:%M:%S") .
+            "<?php /* Smarty version " . Smarty::SMARTY_VERSION . ", created on " . date("Y-m-d H:i:s") .
             "\n";
         $template_header .= "         compiled from '{$this->template->source->filepath}' */ ?>\n";
         $code = '<?php $_smarty_tpl->smarty->ext->configLoad->_loadConfigVars($_smarty_tpl, ' .

--- a/libs/sysplugins/smarty_internal_runtime_codeframe.php
+++ b/libs/sysplugins/smarty_internal_runtime_codeframe.php
@@ -45,7 +45,7 @@ class Smarty_Internal_Runtime_CodeFrame
             $properties[ 'cache_lifetime' ] = $_template->cache_lifetime;
         }
         $output = "<?php\n";
-        $output .= "/* Smarty version {$properties[ 'version' ]}, created on " . strftime("%Y-%m-%d %H:%M:%S") .
+        $output .= "/* Smarty version {$properties[ 'version' ]}, created on " . date("Y-m-d H:i:s") .
                    "\n  from '" . str_replace('*/', '* /', $_template->source->filepath) . "' */\n\n";
         $output .= "/* @var Smarty_Internal_Template \$_smarty_tpl */\n";
         $dec = "\$_smarty_tpl->_decodeProperties(\$_smarty_tpl, " . var_export($properties, true) . ',' .

--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -1135,7 +1135,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
             flush();
         }
         $e = new SmartyCompilerException($error_text);
-        $e->line = $line;
+        $e->setLine($line);
         $e->source = trim(preg_replace('![\t\r\n]+!', ' ', $match[ $line - 1 ]));
         $e->desc = $args;
         $e->template = $this->template->source->filepath;

--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -16,12 +16,12 @@ class SmartyCompilerException extends SmartyException
     }
 
     /**
-     * The line number of the template error
-     *
-     * @type int|null
+     * @param int $line
      */
-    public $line = null;
-
+    public function setLine($line)
+    {
+        $this->line = $line;
+    }
     /**
      * The template source snippet relating to the error
      *

--- a/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
@@ -30,7 +30,8 @@ class CacheResourceTestCommon extends PHPUnit_Smarty
 
     public function compiledPrefilter($text, Smarty_Internal_Template $tpl)
     {
-        return str_replace('#', $tpl->getTemplateVars('test'), $text);
+        $replace = $tpl->getTemplateVars('test');
+        return str_replace('#', $replace ?? '', $text);
     }
 
     /**

--- a/tests/UnitTests/ResourceTests/Stream/StreamResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Stream/StreamResourceTest.php
@@ -234,7 +234,7 @@ class ResourceStream
         $v = &$GLOBALS[$this->varname];
         $l = strlen($data);
         $p = &$this->position;
-        $v = substr($v, 0, $p) . $data . substr($v, $p += $l);
+        $v = substr($v ?? '', 0, $p) . $data . substr($v ?? '', $p += $l);
 
         return $l;
     }

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -344,9 +344,9 @@ class SecurityTest extends PHPUnit_Smarty
 
     /**
      * In security mode, accessing $smarty.template_object should be illegal.
-     * @expectedException SmartyCompilerException
      */
     public function testSmartyTemplateObject() {
+        $this->expectException(SmartyCompilerException::class);
         $this->smarty->display('string:{$smarty.template_object}');
     }
 

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -394,7 +394,7 @@ class ResourceStreamSecurity
         $v = &$GLOBALS[$this->varname];
         $l = strlen($data);
         $p = &$this->position;
-        $v = substr($v, 0, $p) . $data . substr($v, $p += $l);
+        $v = substr($v ?? '', 0, $p) . $data . substr($v ?? '', $p += $l);
 
         return $l;
     }

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -435,9 +435,9 @@ class CompileFunctionTest extends PHPUnit_Smarty
 
     /**
      * Test handling of function names that are a security risk
-     * @expectedException        SmartyCompilerException
      */
     public function testIllegalFunctionName() {
+        $this->expectException(SmartyCompilerException::class);
 	    $this->smarty->fetch('string:{function name=\'rce(){};echo "hi";function \'}{/function}');
     }
 

--- a/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
@@ -96,7 +96,7 @@ class VariableStream
         $v = &$GLOBALS[$this->varname];
         $l = strlen($data);
         $p = &$this->position;
-        $v = substr($v, 0, $p) . $data . substr($v, $p += $l);
+        $v = substr($v ?? '', 0, $p) . $data . substr($v ?? '', $p += $l);
 
         return $l;
     }


### PR DESCRIPTION
The goal of this PR is to make smarty compatible with PHP 8.1.

The main issue was the use of the function `strftime()` which is deprecated in PHP 8.1. This problem is solve by the use of `IntlDateFormatter` after being sure that the `intl` extension is loaded.

Other deprecations have been removed too.