### PR TITLE
[Smarty2] using @count on PHP8 causes a fatal error

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -1208,7 +1208,7 @@ class Smarty
                         $_server_vars = ($this->request_use_auto_globals) ? $_SERVER : $GLOBALS['HTTP_SERVER_VARS'];
                         $_last_modified_date = @substr($_server_vars['HTTP_IF_MODIFIED_SINCE'], 0, strpos($_server_vars['HTTP_IF_MODIFIED_SINCE'], 'GMT') + 3);
                         $_gmt_mtime = gmdate('D, d M Y H:i:s', $this->_cache_info['timestamp']).' GMT';
-                        if (@count($this->_cache_info['insert_tags']) == 0
+                        if (empty($this->_cache_info['insert_tags'])
                             && !$this->_cache_serials
                             && $_gmt_mtime == $_last_modified_date) {
                             if (php_sapi_name()=='cgi')


### PR DESCRIPTION
It seems like 305bf858c1ef44b91913b06291b7ae90c9abe304 didn't contain fix all instances of the problem, which now causes a fatal error in php8

https://github.com/smarty-php/smarty/commit/305bf858c1ef44b91913b06291b7ae90c9abe304



