### PR TITLE
Update project for PHP8.1

### DIFF
--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -18,9 +18,9 @@ class SmartyCompilerException extends SmartyException
     /**
      * The line number of the template error
      *
-     * @type int|null
+     * @type int
      */
-    public $line = null;
+    public $line;
 
     /**
      * The template source snippet relating to the error


### PR DESCRIPTION
Since PHP8.1 is asking strict type, removed `$line = null` default value in smartycompilerexception.php