### PR TITLE
Update modifier.truncate.php

### DIFF
--- a/libs/plugins/modifier.truncate.php
+++ b/libs/plugins/modifier.truncate.php
@@ -29,6 +29,9 @@ function smarty_modifier_truncate($string, $length = 80, $etc = '...', $break_wo
     if ($length === 0) {
         return '';
     }
+    if(empty( $string )) {
+        return;
+    }
     if (Smarty::$_MBSTRING) {
         if (mb_strlen($string, Smarty::$_CHARSET) > $length) {
             $length -= min($length, mb_strlen($etc, Smarty::$_CHARSET));


### PR DESCRIPTION
For PHP 8.1 if string is empty. Repairs Deprecated: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/smarty/smarty/libs/plugins/modifier.truncate.php on line 33