### PR TITLE
Revert regression: no error on array key access

### DIFF
--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -71,7 +71,7 @@ class Smarty_Internal_ErrorHandler
         }
 
         if ($this->allowUndefinedArrayKeys && preg_match(
-            '/^(Undefined array key|Trying to access array offset on value of type null)/',
+            '/^(?:Undefined array key|Trying to access array offset on value of type (?:null|bool))/',
             $errstr
         )) {
             return; // suppresses this error


### PR DESCRIPTION
Makes it so that not only `null` but `false` variables don't throw errors when accessed as array - as it was with Smarty 3.*