### PR TITLE
gitattributes: Ignore `.github` folder for distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,8 @@
 
 # exclude from git export
 /tests export-ignore
-/utilities/ export-ignore
+/utilities export-ignore
+/.github export-ignore
 
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
`.github` wasn't added here was it got created. However, we don't want to include `.github` to release builds (e.g. when installing it through composer).
