### PR TITLE
PHP 8.1: fix deprecation in escape modifier

### DIFF
--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -29,6 +29,9 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
     if (!$char_set) {
         $char_set = Smarty::$_CHARSET;
     }
+
+    $string = (string)$string;
+
     switch ($esc_type) {
         case 'html':
             if ($_double_encode) {

--- a/libs/plugins/modifiercompiler.escape.php
+++ b/libs/plugins/modifiercompiler.escape.php
@@ -42,10 +42,10 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
         switch ($esc_type) {
             case 'html':
                 if ($_double_encode) {
-                    return 'htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
+                    return 'htmlspecialchars((string)' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
                            var_export($double_encode, true) . ')';
                 } elseif ($double_encode) {
-                    return 'htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ')';
+                    return 'htmlspecialchars((string)' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ')';
                 } else {
                     // fall back to modifier.escape.php
                 }
@@ -54,12 +54,12 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 if (Smarty::$_MBSTRING) {
                     if ($_double_encode) {
                         // php >=5.2.3 - go native
-                        return 'mb_convert_encoding(htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' .
+                        return 'mb_convert_encoding(htmlspecialchars((string)' . $params[ 0 ] . ', ENT_QUOTES, ' .
                                var_export($char_set, true) . ', ' . var_export($double_encode, true) .
                                '), "HTML-ENTITIES", ' . var_export($char_set, true) . ')';
                     } elseif ($double_encode) {
                         // php <5.2.3 - only handle double encoding
-                        return 'mb_convert_encoding(htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' .
+                        return 'mb_convert_encoding(htmlspecialchars((string)' . $params[ 0 ] . ', ENT_QUOTES, ' .
                                var_export($char_set, true) . '), "HTML-ENTITIES", ' . var_export($char_set, true) . ')';
                     } else {
                         // fall back to modifier.escape.php
@@ -68,26 +68,26 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 // no MBString fallback
                 if ($_double_encode) {
                     // php >=5.2.3 - go native
-                    return 'htmlentities(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
+                    return 'htmlentities((string)' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
                            var_export($double_encode, true) . ')';
                 } elseif ($double_encode) {
                     // php <5.2.3 - only handle double encoding
-                    return 'htmlentities(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ')';
+                    return 'htmlentities((string)' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ')';
                 } else {
                     // fall back to modifier.escape.php
                 }
             // no break
             case 'url':
-                return 'rawurlencode(' . $params[ 0 ] . ')';
+                return 'rawurlencode((string)' . $params[ 0 ] . ')';
             case 'urlpathinfo':
-                return 'str_replace("%2F", "/", rawurlencode(' . $params[ 0 ] . '))';
+                return 'str_replace("%2F", "/", rawurlencode((string)' . $params[ 0 ] . '))';
             case 'quotes':
                 // escape unescaped single quotes
-                return 'preg_replace("%(?<!\\\\\\\\)\'%", "\\\'",' . $params[ 0 ] . ')';
+                return 'preg_replace("%(?<!\\\\\\\\)\'%", "\\\'", (string)' . $params[ 0 ] . ')';
             case 'javascript':
                 // escape quotes and backslashes, newlines, etc.
                 // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
-                return 'strtr(' .
+                return 'strtr((string)' .
                        $params[ 0 ] .
                        ', array("\\\\" => "\\\\\\\\", "\'" => "\\\\\'", "\"" => "\\\\\"", "\\r" => "\\\\r", "\\n" => "\\\n", "</" => "<\/", "<!--" => "<\!--", "<s" => "<\s", "<S" => "<\S" ))';
         }


### PR DESCRIPTION
In PHP 8.1 is deprecated passing null parameters for string typed parameters. Escape modifier thrown this deprecation:
```
PHP Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in
```

PR fixes this issues.