### PR TITLE
Fix PHP 8.1 deprecated warning when calling rtrim

### DIFF
--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -867,7 +867,7 @@ class Smarty extends Smarty_Internal_TemplateBase
                 $this->plugins_dir = (array)$this->plugins_dir;
             }
             foreach ($this->plugins_dir as $k => $v) {
-                $this->plugins_dir[ $k ] = $this->_realpath(rtrim($v, '/\\') . DIRECTORY_SEPARATOR, true);
+                $this->plugins_dir[ $k ] = $this->_realpath(rtrim($v ?? '', '/\\') . DIRECTORY_SEPARATOR, true);
             }
             $this->_cache[ 'plugin_files' ] = array();
             $this->_pluginsDirNormalized = true;
@@ -1345,7 +1345,7 @@ class Smarty extends Smarty_Internal_TemplateBase
      */
     private function _normalizeDir($dirName, $dir)
     {
-        $this->{$dirName} = $this->_realpath(rtrim($dir, "/\\") . DIRECTORY_SEPARATOR, true);
+        $this->{$dirName} = $this->_realpath(rtrim($dir ?? '', "/\\") . DIRECTORY_SEPARATOR, true);
     }
 
     /**
@@ -1367,7 +1367,7 @@ class Smarty extends Smarty_Internal_TemplateBase
         }
         foreach ($dir as $k => $v) {
             if (!isset($processed[ $k ])) {
-                $dir[ $k ] = $v = $this->_realpath(rtrim($v, "/\\") . DIRECTORY_SEPARATOR, true);
+                $dir[ $k ] = $v = $this->_realpath(rtrim($v ?? '', "/\\") . DIRECTORY_SEPARATOR, true);
                 $processed[ $k ] = true;
             }
         }

--- a/libs/sysplugins/smarty_internal_compile_insert.php
+++ b/libs/sysplugins/smarty_internal_compile_insert.php
@@ -93,7 +93,7 @@ class Smarty_Internal_Compile_Insert extends Smarty_Internal_CompileBase
                 }
                 if (!empty($_dir)) {
                     foreach ((array)$_dir as $_script_dir) {
-                        $_script_dir = rtrim($_script_dir, '/\\') . DIRECTORY_SEPARATOR;
+                        $_script_dir = rtrim($_script_dir ?? '', '/\\') . DIRECTORY_SEPARATOR;
                         if (file_exists($_script_dir . $_script)) {
                             $_filepath = $_script_dir . $_script;
                             break;

--- a/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
+++ b/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
@@ -13,7 +13,7 @@ class Smarty_Resource_Ambiguous extends Smarty_Internal_Resource_File
 
     public function __construct($directory)
     {
-        $this->directory = rtrim($directory, "/\\") . DIRECTORY_SEPARATOR;
+        $this->directory = rtrim($directory ?? '', "/\\") . DIRECTORY_SEPARATOR;
         //        parent::__construct();
     }
 


### PR DESCRIPTION
Fixes - Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated