### PR TITLE
Support PHP 8.1 for version 2.6: Fix deprecated warning when calling strftime for template compiling

### DIFF
--- a/libs/Smarty_Compiler.class.php
+++ b/libs/Smarty_Compiler.class.php
@@ -391,7 +391,7 @@ class Smarty_Compiler extends Smarty {
         }
 
         // put header at the top of the compiled template
-        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".strftime("%Y-%m-%d %H:%M:%S")."\n";
+        $template_header = "<?php /* Smarty version ".$this->_version.", created on ".date("Y-m-d H:i:s")."\n";
         $template_header .= "         compiled from ".strtr(urlencode($resource_name), array('%2F'=>'/', '%3A'=>':'))." */ ?>\n";
 
         /* Emit code to load needed plugins. */

--- a/libs/internals/core.write_compiled_include.php
+++ b/libs/internals/core.write_compiled_include.php
@@ -25,7 +25,7 @@ function smarty_core_write_compiled_include($params, &$smarty)
     if (count($_match_source)==0) return;
 
     // convert the matched php-code to functions
-    $_include_compiled =  "<?php /* Smarty version ".$smarty->_version.", created on ".strftime("%Y-%m-%d %H:%M:%S")."\n";
+    $_include_compiled =  "<?php /* Smarty version ".$smarty->_version.", created on ".date("Y-m-d H:i:s")."\n";
     $_include_compiled .= "         compiled from " . strtr(urlencode($params['resource_name']), array('%2F'=>'/', '%3A'=>':')) . " */\n\n";
 
     $_compile_path = $params['include_file_path'];


### PR DESCRIPTION
Fixes deprecation of strftime() since PHP 8.1 in branch support/2.6.