### PR TITLE
address PHP 8.1 'explode', 'number_format', and 'replace' deprecations

### DIFF
--- a/libs/plugins/modifier.explode.php
+++ b/libs/plugins/modifier.explode.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+
+/**
+ * Smarty explode modifier plugin
+ * Type:     modifier
+ * Name:     explode
+ * Purpose:  split a string by a string
+ *
+ * @param string   $separator
+ * @param string   $string
+ * @param int|null $limit
+ *
+ * @return array
+ */
+function smarty_modifier_explode($separator, $string, ?int $limit = null)
+{
+    // provide $string default to prevent deprecation errors in PHP >=8.1
+    return explode($separator, $string ?? '', $limit ?? PHP_INT_MAX);
+}

--- a/libs/plugins/modifier.number_format.php
+++ b/libs/plugins/modifier.number_format.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+
+/**
+ * Smarty number_format modifier plugin
+ * Type:     modifier
+ * Name:     number_format
+ * Purpose:  Format a number with grouped thousands
+ *
+ * @param float|null  $num
+ * @param int         $decimals
+ * @param string|null $decimal_separator
+ * @param string|null $thousands_separator
+ *
+ * @return string
+ */
+function smarty_modifier_number_format(?float $num, int $decimals = 0, ?string $decimal_separator = ".", ?string $thousands_separator = ",")
+{
+    // provide $num default to prevent deprecation errors in PHP >=8.1
+    return number_format($num ?? 0.0, $decimals, $decimal_separator, $thousands_separator);
+}

--- a/libs/plugins/shared.mb_str_replace.php
+++ b/libs/plugins/shared.mb_str_replace.php
@@ -62,7 +62,7 @@ if (!function_exists('smarty_mb_str_replace')) {
                 $replace = mb_convert_encoding($replace, $current_charset, Smarty::$_CHARSET);
             }
 
-            $parts = mb_split(preg_quote($search), $subject) ?: array();
+            $parts = mb_split(preg_quote($search), $subject ?? "") ?: array();
             // If original regex encoding was not unicode...
             if(!$reg_is_unicode) {
                 // ...restore original regex encoding to avoid breaking the system.

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierExplodeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierExplodeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UnitTests\TemplateSource\TagTests\PluginModifier;
+
+/**
+ * class for modifier tests
+ *
+ * @runTestsInSeparateProcess
+ * @preserveGlobalState disabled
+ * @backupStaticAttributes enabled
+ */
+class PluginModifierExplodeTest extends \PHPUnit_Smarty
+{
+    public function setUp(): void
+    {
+        $this->setUpSmarty(__DIR__);
+    }
+
+    /**
+     * @return void
+     * @throws \SmartyException
+     *
+     * @dataProvider explodeDataProvider
+     */
+    public function testExplode($template, $subject, $expectedString)
+    {
+        $this->smarty->assign('subject', $subject);
+
+        $tpl = $this->smarty->createTemplate($template);
+        $res = $this->smarty->fetch($tpl);
+
+        $this->assertEquals($expectedString, $res);
+    }
+
+    public function explodeDataProvider()
+    {
+        return [
+            'default'  => [
+                'template'      => 'string:{","|explode:$subject|json_encode}',
+                'subject'       => 'a,b,c,d',
+                'expectedString' => '["a","b","c","d"]',
+            ],
+            'withNoDelimiterFound'  => [
+                'template'      => 'string:{","|explode:$subject|json_encode}',
+                'subject'       => 'abcd',
+                'expectedString' => '["abcd"]',
+            ],
+            'withNull' => [
+                'template'      => 'string:{","|explode:$subject|json_encode}',
+                'subject'       => null,
+                'expectedString' => '[""]',
+            ],
+        ];
+    }
+}

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierNumberFormatTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierNumberFormatTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UnitTests\TemplateSource\TagTests\PluginModifier;
+
+/**
+ * class for modifier tests
+ *
+ * @runTestsInSeparateProcess
+ * @preserveGlobalState disabled
+ * @backupStaticAttributes enabled
+ */
+class PluginModifierNumberFormatTest extends \PHPUnit_Smarty
+{
+    public function setUp(): void
+    {
+        $this->setUpSmarty(__DIR__);
+    }
+
+    /**
+     * @return void
+     * @throws \SmartyException
+     *
+     * @dataProvider numberFormatDataProvider
+     */
+    public function testNumberFormat($template, $subject, $expectedString)
+    {
+        $this->smarty->assign('subject', $subject);
+
+        $tpl = $this->smarty->createTemplate($template);
+
+        $this->assertEquals($expectedString, $this->smarty->fetch($tpl));
+    }
+
+    public function numberFormatDataProvider()
+    {
+        return [
+            'default'  => [
+                'template'      => 'string:{$subject|number_format}',
+                'subject'       => 12345,
+                'expectedString' => "12,345",
+            ],
+            'withDecimalDefault'  => [
+                'template'      => 'string:{$subject|number_format}',
+                'subject'       => 12345.6789,
+                'expectedString' => "12,346",
+            ],
+            'withDecimalAndExtras'  => [
+                'template'      => 'string:{$subject|number_format:2:"-":"~"}',
+                'subject'       => 12345.6789,
+                'expectedString' => "12~345-68",
+            ],
+            'withNull' => [
+                'template'      => 'string:{$subject|number_format}',
+                'subject'       => null,
+                'expectedString' => 0,
+            ],
+        ];
+    }
+}

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierReplaceTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierReplaceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace UnitTests\TemplateSource\TagTests\PluginModifier;
+
+/**
+ * class for modifier tests
+ *
+ * @runTestsInSeparateProcess
+ * @preserveGlobalState disabled
+ * @backupStaticAttributes enabled
+ */
+class PluginModifierReplaceTest extends \PHPUnit_Smarty
+{
+    public function setUp(): void
+    {
+        $this->setUpSmarty(__DIR__);
+    }
+
+    /**
+     * @return void
+     * @throws \SmartyException
+     *
+     * @dataProvider replaceDataProvider
+     */
+    public function testReplace($template, $subject, $expectedString)
+    {
+        $this->smarty->assign('subject', $subject);
+
+        $tpl = $this->smarty->createTemplate($template);
+
+        $this->assertEquals($expectedString, $this->smarty->fetch($tpl));
+    }
+
+    public function replaceDataProvider()
+    {
+        return [
+            'default'  => [
+                'template'      => 'string:{$subject|replace:",":"-"}',
+                'subject'       => "a,b,c,d",
+                'expectedString' => "a-b-c-d",
+            ],
+            'doNothing'  => [
+                'template'      => 'string:{$subject|replace:"":""}',
+                'subject'       => "a,b,c,d",
+                'expectedString' => "a,b,c,d",
+            ],
+            'withNull' => [
+                'template'      => 'string:{$subject|replace:"":""}',
+                'subject'       => null,
+                'expectedString' => "",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR is meant to address several of the PHP 8.1 deprecation items noted in Issue #750 

It does not address the deprecation noted in 'escape' because I was not able to recreate the issue against the current master branch

It also does not address any strftime() related deprecation issues since it is not clear to me how that issue should be addressed as a whole. Discussions were present in #678 and touched on using an intl polyfill, but changes were deferred at that time.  #672 is open as a strftime() specific issue so I suppose it would still be handled there unless a decision has already been made, in which case I would be happy to update this PR once I know how it should be handled.