### PR TITLE
Fix PHP 8.1 htmlspecialchars deprecation

### DIFF
--- a/libs/sysplugins/smarty_internal_compile_private_print_expression.php
+++ b/libs/sysplugins/smarty_internal_compile_private_print_expression.php
@@ -93,7 +93,7 @@ class Smarty_Internal_Compile_Private_Print_Expression extends Smarty_Internal_C
                 }
                 // autoescape html
                 if ($compiler->template->smarty->escape_html) {
-                    $output = "htmlspecialchars({$output}, ENT_QUOTES, '" . addslashes(Smarty::$_CHARSET) . "')";
+                    $output = "htmlspecialchars((string) {$output}, ENT_QUOTES, '" . addslashes(Smarty::$_CHARSET) . "')";
                 }
                 // loop over registered filters
                 if (!empty($compiler->template->smarty->registered_filters[ Smarty::FILTER_VARIABLE ])) {


### PR DESCRIPTION
Fixes a remaining PHP 8.1 deprecation error for `htmlspecialchars` (issue #750) which was not covered by the PR #727.