### PR TITLE
Do not use obsolete smarty properties '_dir_perms', '_file_perms', 'p…

### DIFF
--- a/libs/sysplugins/smarty_internal_runtime_writefile.php
+++ b/libs/sysplugins/smarty_internal_runtime_writefile.php
@@ -29,12 +29,7 @@ class Smarty_Internal_Runtime_WriteFile
     {
         $_error_reporting = error_reporting();
         error_reporting($_error_reporting & ~E_NOTICE & ~E_WARNING);
-        $_file_perms = property_exists($smarty, '_file_perms') ? $smarty->_file_perms : 0644;
-        $_dir_perms =
-            property_exists($smarty, '_dir_perms') ? (isset($smarty->_dir_perms) ? $smarty->_dir_perms : 0777) : 0771;
-        if ($_file_perms !== null) {
-            $old_umask = umask(0);
-        }
+        $old_umask = umask(0);
         $_dirpath = dirname($_filepath);
         // if subdirs, create dir structure
         if ($_dirpath !== '.') {
@@ -42,7 +37,7 @@ class Smarty_Internal_Runtime_WriteFile
             // loop if concurrency problem occurs
             // see https://bugs.php.net/bug.php?id=35326
             while (!is_dir($_dirpath)) {
-                if (@mkdir($_dirpath, $_dir_perms, true)) {
+                if (@mkdir($_dirpath, 0771, true)) {
                     break;
                 }
                 clearstatcache();
@@ -89,11 +84,9 @@ class Smarty_Internal_Runtime_WriteFile
             error_reporting($_error_reporting);
             throw new SmartyException("unable to write file {$_filepath}");
         }
-        if ($_file_perms !== null) {
-            // set file permissions
-            chmod($_filepath, $_file_perms);
-            umask($old_umask);
-        }
+        // set file permissions
+        chmod($_filepath, 0644);
+        umask($old_umask);
         error_reporting($_error_reporting);
         return true;
     }

--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -422,9 +422,6 @@ abstract class Smarty_Internal_TemplateCompilerBase
         try {
             // save template object in compiler class
             $this->template = $template;
-            if (property_exists($this->template->smarty, 'plugin_search_order')) {
-                $this->plugin_search_order = $this->template->smarty->plugin_search_order;
-            }
             if ($this->smarty->debugging) {
                 if (!isset($this->smarty->_debug)) {
                     $this->smarty->_debug = new Smarty_Internal_Debug();


### PR DESCRIPTION
…lugin_search_order' in our own code.