### PR TITLE
Make SmartyCompilerException play nicer with error handler libraries

### DIFF
--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -1131,12 +1131,12 @@ abstract class Smarty_Internal_TemplateCompilerBase
             echo ob_get_clean();
             flush();
         }
-        $e = new SmartyCompilerException($error_text);
-        $e->setLine($line);
-        $e->source = trim(preg_replace('![\t\r\n]+!', ' ', $match[ $line - 1 ]));
-        $e->desc = $args;
-        $e->template = $this->template->source->filepath;
-        throw $e;
+        throw new SmartyCompilerException(
+            $error_text,
+            0,
+            $this->template->source->filepath,
+            $line
+        );
     }
 
     /**

--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -8,38 +8,37 @@
 class SmartyCompilerException extends SmartyException
 {
     /**
+     * The constructor of the exception
+     *
+     * @param string         $message  The Exception message to throw.
+     * @param int            $code     The Exception code.
+     * @param string|null    $filename The filename where the exception is thrown.
+     * @param int|null       $line     The line number where the exception is thrown.
+     * @param Throwable|null $previous The previous exception used for the exception chaining.
+     */
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        ?string $filename = null,
+        ?int $line = null,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+
+        // These are optional parameters, should be be overridden only when present!
+        if ($filename) {
+            $this->file = $filename;
+        }
+        if ($line) {
+            $this->line = $line;
+        }
+    }
+
+    /**
      * @return string
      */
     public function __toString()
     {
         return ' --> Smarty Compiler: ' . $this->message . ' <-- ';
     }
-
-    /**
-     * @param int $line
-     */
-    public function setLine($line)
-    {
-        $this->line = $line;
-    }
-    /**
-     * The template source snippet relating to the error
-     *
-     * @type string|null
-     */
-    public $source = null;
-
-    /**
-     * The raw text of the error message
-     *
-     * @type string|null
-     */
-    public $desc = null;
-
-    /**
-     * The resource identifier or template name
-     *
-     * @type string|null
-     */
-    public $template = null;
 }


### PR DESCRIPTION
When a `SmartyCompilerException` is thrown, the `Exception::$line` is changed to the line of the template, but `Exception::$file` wasn't.

This resulted in error handler libraries (filp/whoops, nunomaduro/collision, spatie/ignition, sentry/sentry, etc.) displaying the wrong file in the error message, as they display the `Exception::$file` (through `getFile()`), but `SmartyCompilerException::$template` was the variable where the filename was written into. Not to mention that `$line` was the only property set with a setter method, everything else was public properties set directly, which was inconsistent.

This behaviour can be checked at https://original-smarty.displeases.me/ (along with the [composer.json file](https://original-smarty.displeases.me/composer.json)).

In this merge request, I have written a new constructor for `SmartyCompilerException`, which can optionally change the file and the line if provided with these parameters.

This new constructor can be observed in action at https://fixing-smarty.displeases.me/ (along with the [composer.json file](https://fixing-smarty.displeases.me/composer.json)).

According to the composer.json file, Smarty requires at least PHP 7.1, so the type declarations I've used should not be a problem: https://3v4l.org/o8Yrb

The unit tests provided by Smarty all passed, **but** me removing `$source`, `$template`, and `$desc` is a breaking change for any users who were manually handling (or throwing?) `SmartyCompilerException` themselves.