### PR TITLE
Fix deprecations #750 for smarty3.1

### DIFF
--- a/libs/plugins/modifier.date_format.php
+++ b/libs/plugins/modifier.date_format.php
@@ -28,6 +28,195 @@
  */
 function smarty_modifier_date_format($string, $format = null, $default_date = '', $formatter = 'auto')
 {
+    /**
+     * Anonymous function, only used if version_compare >= PHP8.1
+     *
+     * Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)
+     * This provides a cross-platform alternative to strftime() for when it will be removed from PHP.
+     * Note that output can be slightly different between libc sprintf and this function as it is using ICU.
+     * Usage:
+     * use func \PHP81_BC\strftime;
+     * echo strftime('%A %e %B %Y %X', new \DateTime('2021-09-28 00:00:00'), 'fr_FR');
+     * Original use:
+     * \setlocale('fr_FR.UTF-8', LC_TIME);
+     * echo \strftime('%A %e %B %Y %X', strtotime('2021-09-28 00:00:00'));
+     *
+     * @param string                  $format    Date format
+     * @param integer|string|DateTime $timestamp Timestamp
+     *
+     * @return string
+     * @author BohwaZ <https://bohwaz.net/>
+     * @quthor modified by https://github.com/cmelius
+     */
+    $php81strftime = function (string $format, $timestamp = null): string
+    {
+
+        if (null === $timestamp) {
+            $timestamp = new \DateTime;
+        } elseif (is_numeric($timestamp)) {
+            $timestamp = date_create('@' . $timestamp);
+        } elseif (is_string($timestamp)) {
+            $timestamp = date_create('!' . $timestamp);
+        }
+
+        if (!($timestamp instanceof \DateTimeInterface)) {
+            throw new \InvalidArgumentException('$timestamp argument is neither a valid UNIX timestamp, a valid date-time string or a DateTime object.');
+        }
+
+        $intl_formats = [
+            '%a' => 'EEE',
+            // An abbreviated textual representation of the day	Sun through Sat
+            '%A' => 'EEEE',
+            // A full textual representation of the day	Sunday through Saturday
+            '%b' => 'MMM',
+            // Abbreviated month name, based on the locale	Jan through Dec
+            '%B' => 'MMMM',
+            // Full month name, based on the locale	January through December
+            '%h' => 'MMM',
+            // Abbreviated month name, based on the locale (an alias of %b)	Jan through Dec
+            '%p' => 'aa',
+            // UPPER-CASE 'AM' or 'PM' based on the given time	Example: AM for 00:31, PM for 22:23
+            '%P' => 'aa',
+            // lower-case 'am' or 'pm' based on the given time	Example: am for 00:31, pm for 22:23
+        ];
+
+        $intl_formatter = function (\DateTimeInterface $timestamp, string $format) use ($intl_formats) {
+
+            $tz = $timestamp->getTimezone();
+            $date_type = IntlDateFormatter::FULL;
+            $time_type = IntlDateFormatter::FULL;
+            $pattern = '';
+
+            // %c = Preferred date and time stamp based on locale
+            // Example: Tue Feb 5 00:45:10 2009 for February 5, 2009 at 12:45:10 AM
+            if ($format == '%c') {
+                $date_type = IntlDateFormatter::LONG;
+                $time_type = IntlDateFormatter::SHORT;
+            }
+            // %x = Preferred date representation based on locale, without the time
+            // Example: 02/05/09 for February 5, 2009
+            elseif ($format == '%x') {
+                $date_type = IntlDateFormatter::SHORT;
+                $time_type = IntlDateFormatter::NONE;
+            } // Localized time format
+            elseif ($format == '%X') {
+                $date_type = IntlDateFormatter::NONE;
+                $time_type = IntlDateFormatter::MEDIUM;
+            } else {
+                $pattern = $intl_formats[ $format ];
+            }
+
+            return (new IntlDateFormatter(null, $date_type, $time_type, $tz, null, $pattern))->format($timestamp);
+        };
+
+        // Same order as https://www.php.net/manual/en/function.strftime.php
+        $translation_table = [
+            // Day
+            '%a' => $intl_formatter,
+            '%A' => $intl_formatter,
+            '%d' => 'd',
+            '%e' => 'j',
+            '%j' => function ($timestamp) {
+
+                // Day number in year, 001 to 366
+                return sprintf('%03d', $timestamp->format('z') + 1);
+            },
+            '%u' => 'N',
+            '%w' => 'w',
+
+            // Week
+            '%U' => function ($timestamp) {
+
+                // Number of weeks between date and first Sunday of year
+                $day = new \DateTime(sprintf('%d-01 Sunday', $timestamp->format('Y')));
+
+                return intval(($timestamp->format('z') - $day->format('z')) / 7);
+            },
+            '%W' => function ($timestamp) {
+
+                // Number of weeks between date and first Monday of year
+                $day = new \DateTime(sprintf('%d-01 Monday', $timestamp->format('Y')));
+
+                return intval(($timestamp->format('z') - $day->format('z')) / 7);
+            },
+            '%V' => 'W',
+
+            // Month
+            '%b' => $intl_formatter,
+            '%B' => $intl_formatter,
+            '%h' => $intl_formatter,
+            '%m' => 'm',
+
+            // Year
+            '%C' => function ($timestamp) {
+
+                // Century (-1): 19 for 20th century
+                return (int)$timestamp->format('Y') / 100;
+            },
+            '%g' => function ($timestamp) {
+
+                return substr($timestamp->format('o'), -2);
+            },
+            '%G' => 'o',
+            '%y' => 'y',
+            '%Y' => 'Y',
+
+            // Time
+            '%H' => 'H',
+            '%k' => 'G',
+            '%I' => 'h',
+            '%l' => 'g',
+            '%M' => 'i',
+            '%p' => $intl_formatter,
+            // AM PM (this is reversed on purpose!)
+            '%P' => $intl_formatter,
+            // am pm
+            '%r' => 'G:i:s A',
+            // %I:%M:%S %p
+            '%R' => 'H:i',
+            // %H:%M
+            '%S' => 's',
+            '%X' => $intl_formatter,
+            // Preferred time representation based on locale, without the date
+
+            // Timezone
+            '%z' => 'O',
+            '%Z' => 'T',
+
+            // Time and Date Stamps
+            '%c' => $intl_formatter,
+            '%D' => 'm/d/Y',
+            '%F' => 'Y-m-d',
+            '%s' => 'U',
+            '%x' => $intl_formatter,
+        ];
+
+        $out = preg_replace_callback('/(?<!%)(%[a-zA-Z])/', function ($match) use ($translation_table, $timestamp) {
+
+            if ($match[1] == '%n') {
+                return "\n";
+            } elseif ($match[1] == '%t') {
+                return "\t";
+            }
+
+            if (!isset($translation_table[ $match[1] ])) {
+                throw new \InvalidArgumentException(sprintf('Format "%s" is unknown in time format', $match[1]));
+            }
+
+            $replace = $translation_table[ $match[1] ];
+
+            if (is_string($replace)) {
+                return $timestamp->format($replace);
+            } else {
+                return $replace($timestamp, $match[1]);
+            }
+        }, $format);
+
+        $out = str_replace('%%', '%', $out);
+
+        return $out;
+    };
+
     if ($format === null) {
         $format = Smarty::$_DATE_FORMAT;
     }
@@ -77,6 +266,10 @@ function smarty_modifier_date_format($string, $format = null, $default_date = ''
                 $_win_to[] = sprintf('%\' 2d', date('h', $timestamp));
             }
             $format = str_replace($_win_from, $_win_to, $format);
+        }
+
+        if (version_compare(PHP_VERSION, '8.1', '>=')) {
+            return $php81strftime($format, $timestamp);
         }
         return strftime($format, $timestamp);
     } else {

--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -36,7 +36,8 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
         case 'html':
             if ($_double_encode) {
                 // php >=5.3.2 - go native
-                return htmlspecialchars($string, ENT_QUOTES, $char_set, $double_encode);
+                // do not use null coalescing operator to stay compatible with php < 7
+                return htmlspecialchars(null !== $string ? $string : '', ENT_QUOTES, $char_set, $double_encode);
             } else {
                 if ($double_encode) {
                     // php <5.2.3 - only handle double encoding
@@ -65,7 +66,8 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
                 // mb_convert_encoding ignores htmlspecialchars()
                 if ($_double_encode) {
                     // php >=5.3.2 - go native
-                    $string = htmlspecialchars($string, ENT_QUOTES, $char_set, $double_encode);
+                    // do not use null coalescing operator to stay compatible with php < 7
+                    $string = htmlspecialchars(null !== $string ? $string : '', ENT_QUOTES, $char_set, $double_encode);
                 } else {
                     if ($double_encode) {
                         // php <5.2.3 - only handle double encoding
@@ -94,7 +96,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
             }
             // no MBString fallback
             if ($_double_encode) {
-                return htmlentities($string, ENT_QUOTES, $char_set, $double_encode);
+                return htmlentities(null !== $string ? $string : '', ENT_QUOTES, $char_set, $double_encode);
             } else {
                 if ($double_encode) {
                     return htmlentities($string, ENT_QUOTES, $char_set);

--- a/libs/plugins/modifier.explode.php
+++ b/libs/plugins/modifier.explode.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty explode modifier plugin
+ * Type:     modifier
+ * Name:     explode
+ * Purpose:  php explode wrapper to fix PHP 8.1 "Passing null to parameter #2 ($string) of type string is deprecated"
+ *
+ * @author Christian Meius <https://github.com/cmelius>
+ *
+ * @param string $separator string to seperate $string with
+ * @param string $string  text to seperate
+ * @param string $limit max replacements
+ *
+ * @return array
+ */
+function smarty_modifier_explode($separator, $string, $limit = PHP_INT_MAX)
+{
+    static $is_loaded = false;
+
+    $string = null !== $string ? $string : '';
+
+    return explode($separator, $string, $limit);
+}

--- a/libs/plugins/modifier.explode.php
+++ b/libs/plugins/modifier.explode.php
@@ -21,8 +21,6 @@
  */
 function smarty_modifier_explode($separator, $string, $limit = PHP_INT_MAX)
 {
-    static $is_loaded = false;
-
     $string = null !== $string ? $string : '';
 
     return explode($separator, $string, $limit);

--- a/libs/plugins/modifier.number_format.php
+++ b/libs/plugins/modifier.number_format.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty number_format modifier plugin
+ * Type:     modifier
+ * Name:     number-format
+ * Purpose:  php number_format wrapper to fix PHP 8.1 "Passing null to parameter #1 ($num) of type float is deprecated"
+ *
+ * @author Christian Meius <https://github.com/cmelius>
+ *
+ * @param string $num number to format
+ * @param string $decimals  number of decimals
+ * @param string $decimal_separator
+ * @param string $thousands_separator
+ *
+ * @return string
+ */
+function smarty_modifier_number_format($num, $decimals = 0, $decimal_separator =".", $thousands_separator = ",")
+{
+    static $is_loaded = false;
+
+    $num = null !== $num ? $num : 0;
+
+    return number_format($num, $decimals, $decimal_separator, $thousands_separator);
+}

--- a/libs/plugins/modifier.number_format.php
+++ b/libs/plugins/modifier.number_format.php
@@ -22,8 +22,6 @@
  */
 function smarty_modifier_number_format($num, $decimals = 0, $decimal_separator =".", $thousands_separator = ",")
 {
-    static $is_loaded = false;
-
     $num = null !== $num ? $num : 0;
 
     return number_format($num, $decimals, $decimal_separator, $thousands_separator);

--- a/libs/plugins/modifiercompiler.escape.php
+++ b/libs/plugins/modifiercompiler.escape.php
@@ -45,7 +45,7 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
         switch ($esc_type) {
             case 'html':
                 if ($_double_encode) {
-                    return 'htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
+                    return 'htmlspecialchars(' . null !==  $params[ 0 ] ?  $params[ 0 ] : '\'\'' . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
                            var_export($double_encode, true) . ')';
                 } elseif ($double_encode) {
                     return 'htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ')';
@@ -57,7 +57,7 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 if (Smarty::$_MBSTRING) {
                     if ($_double_encode) {
                         // php >=5.2.3 - go native
-                        return 'mb_convert_encoding(htmlspecialchars(' . $params[ 0 ] . ', ENT_QUOTES, ' .
+                        return 'mb_convert_encoding(htmlspecialchars(' . null !==  $params[ 0 ] ?  $params[ 0 ] : '\'\'' . ', ENT_QUOTES, ' .
                                var_export($char_set, true) . ', ' . var_export($double_encode, true) .
                                '), "HTML-ENTITIES", ' . var_export($char_set, true) . ')';
                     } elseif ($double_encode) {
@@ -71,7 +71,7 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 // no MBString fallback
                 if ($_double_encode) {
                     // php >=5.2.3 - go native
-                    return 'htmlentities(' . $params[ 0 ] . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
+                    return 'htmlentities(' . null !==  $params[ 0 ] ?  $params[ 0 ] : '\'\'' . ', ENT_QUOTES, ' . var_export($char_set, true) . ', ' .
                            var_export($double_encode, true) . ')';
                 } elseif ($double_encode) {
                     // php <5.2.3 - only handle double encoding

--- a/libs/plugins/modifiercompiler.upper.php
+++ b/libs/plugins/modifiercompiler.upper.php
@@ -20,9 +20,13 @@
  */
 function smarty_modifiercompiler_upper($params)
 {
+    $stringtoupper = $params[0];
+    if (version_compare(PHP_VERSION, '8.1', '>=')) {
+        $stringtoupper .= ' ?? \'\'';
+    }
     if (Smarty::$_MBSTRING) {
-        return 'mb_strtoupper(' . $params[ 0 ] . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
+        return 'mb_strtoupper(' . $stringtoupper . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
     }
     // no MBString fallback
-    return 'strtoupper(' . $params[ 0 ] . ')';
+    return 'strtoupper(' . $stringtoupper . ')';
 }

--- a/libs/plugins/shared.mb_str_replace.php
+++ b/libs/plugins/shared.mb_str_replace.php
@@ -62,6 +62,8 @@ if (!function_exists('smarty_mb_str_replace')) {
                 $replace = mb_convert_encoding($replace, $current_charset, Smarty::$_CHARSET);
             }
 
+            // work around for PHP8.1 "Deprecated: mb_split(): Passing null to parameter #2 ($string) of type string is deprecated"
+            $subject = null !== $subject ? $subject : '';
             $parts = mb_split(preg_quote($search), $subject);
             // If original regex encoding was not unicode...
             if(!$reg_is_unicode) {


### PR DESCRIPTION
Attempt to fix #750 for smarty3.1 branch.

Please take a look. 
One problem might be, that modifier_date_format uses intl. extension here (only if PHP >= 8.1). Are you ok with that?
