### PR TITLE
Fixed use of `rand()` without a parameter in math function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed PHP8.1 deprecation errors in modifiers (upper, explode, number_format and replace) [#755](https://github.com/smarty-php/smarty/pull/755) and [#788](https://github.com/smarty-php/smarty/pull/788)
+- Fixed use of `rand()` without a parameter in math function [#794](https://github.com/smarty-php/smarty/issues/794)
 
 ## [4.2.0] - 2022-08-01
 

--- a/libs/plugins/function.math.php
+++ b/libs/plugins/function.math.php
@@ -70,7 +70,7 @@ function smarty_function_math($params, $template)
     $number = '(?:\d+(?:[,.]\d+)?|pi|π)'; // What is a number
     $functionsOrVars = '((?:0x[a-fA-F0-9]+)|([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))';
     $operators = '[,+\/*\^%-]'; // Allowed math operators
-    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)*\)|\((?1)+\)))(?:'.$operators.'(?1))?)+$/';
+    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)*\)|\((?1)*\)))(?:'.$operators.'(?1))?)+$/';
 
     if (!preg_match($regexp, $equation)) {
         trigger_error("math: illegal characters", E_USER_WARNING);

--- a/libs/plugins/function.math.php
+++ b/libs/plugins/function.math.php
@@ -70,7 +70,7 @@ function smarty_function_math($params, $template)
     $number = '(?:\d+(?:[,.]\d+)?|pi|π)'; // What is a number
     $functionsOrVars = '((?:0x[a-fA-F0-9]+)|([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))';
     $operators = '[,+\/*\^%-]'; // Allowed math operators
-    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)+\)|\((?1)+\)))(?:'.$operators.'(?1))?)+$/';
+    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)*\)|\((?1)+\)))(?:'.$operators.'(?1))?)+$/';
 
     if (!preg_match($regexp, $equation)) {
         trigger_error("math: illegal characters", E_USER_WARNING);

--- a/tests/UnitTests/TemplateSource/ValueTests/Math/MathTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Math/MathTest.php
@@ -156,4 +156,12 @@ class MathTest extends PHPUnit_Smarty
 		$this->assertEquals($expected, $this->smarty->fetch($tpl));
 	}
 
+	public function testRand()
+	{
+		$tpl = $this->smarty->createTemplate('eval:{$x = "0"}{math equation="x * rand()" x=$x}');
+		// this assertion may seem silly, but it serves to prove that using rand() without a parameter
+		// will not trigger a security error (see https://github.com/smarty-php/smarty/issues/794)
+		$this->assertEquals("0", $this->smarty->fetch($tpl));
+	}
+
 }


### PR DESCRIPTION
Fixes #794