### PR TITLE
fix compilation for caching templates

### DIFF
--- a/libs/sysplugins/smarty_internal_template.php
+++ b/libs/sysplugins/smarty_internal_template.php
@@ -292,7 +292,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
         $smarty = &$this->smarty;
         $_templateId = $smarty->_getTemplateId($template, $cache_id, $compile_id, $caching, $tpl);
         // recursive call ?
-        if (isset($tpl->templateId) ? $tpl->templateId : $tpl->_getTemplateId() !== $_templateId) {
+        if ((isset($tpl->templateId) ? $tpl->templateId : $tpl->_getTemplateId()) !== $_templateId) {
             // already in template cache?
             if (isset(self::$tplObjCache[ $_templateId ])) {
                 // copy data from cached object
@@ -358,7 +358,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
         }
         if ($tpl->caching === 9999) {
             if (!isset($tpl->compiled)) {
-                $this->loadCompiled(true);
+                $tpl->loadCompiled(true);
             }
             if ($tpl->compiled->has_nocache_code) {
                 $this->cached->hashes[ $tpl->compiled->nocache_hash ] = true;


### PR DESCRIPTION
We maintain a complex template setup using inheritance and includes. 
When activating caching, we get an out of memory error due to a non-terminating recursion. 
After stepping through the code there seem to be two possible causes, which when corrected resolve the issue.

The first one being missing parenthesis around the ternary operator which leads to a wrong comparison.

With the second one it seems that the wrong template was compiled.

PHP-version: 8.0
Smarty-version: 4.2.0