### PR TITLE
Fix wrong indentation in libs/plugins/modifier.capitalize.php

### DIFF
--- a/libs/plugins/modifier.capitalize.php
+++ b/libs/plugins/modifier.capitalize.php
@@ -22,7 +22,7 @@
  */
 function smarty_modifier_capitalize($string, $uc_digits = false, $lc_rest = false)
 {
-	$string = (string) $string;
+    $string = (string) $string;
 
     if (Smarty::$_MBSTRING) {
         if ($lc_rest) {


### PR DESCRIPTION
Introduced in https://github.com/smarty-php/smarty/commit/d304d349b4deb19c84742b29b53bb3f8e59413fc