### PR TITLE
revert php constraints to not force major updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "forum": "http://www.smarty.net/forums/"
     },
     "require": {
-        "php": "^5.2 || ^7.0"
+        "php": ">=5.2"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
the change in the php constraints forces codebases using php 8 to upgrade to the next major.
this changes should not be made in a patch update 