### PR TITLE
Fixed PHP8.1 deprecation errors passing null to parameter in trim

### DIFF
--- a/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
+++ b/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
@@ -244,7 +244,7 @@ abstract class Smarty_CacheResource_KeyValueStore extends Smarty_CacheResource
      */
     protected function sanitize($string)
     {
-        $string = trim($string, '|');
+        $string = trim((string)$string, '|');
         if (!$string) {
             return '';
         }
@@ -428,7 +428,7 @@ abstract class Smarty_CacheResource_KeyValueStore extends Smarty_CacheResource
             $t[] = 'IVK#COMPILE' . $_compile;
         }
         $_name .= '#';
-        $cid = trim($cache_id, '|');
+        $cid = trim((string)$cache_id, '|');
         if (!$cid) {
             return $t;
         }


### PR DESCRIPTION
Fixed a PHP 8.1 deprecation error:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in cacheresource_keyvaluestore.php on line 247 and in cacheresource_keyvaluestore.php on line 431