### PR TITLE
Use '__DIR__' instead of 'dirname(__FILE__)'

### DIFF
--- a/libs/Autoloader.php
+++ b/libs/Autoloader.php
@@ -7,7 +7,7 @@
 
 
 if (!defined('SMARTY_HELPER_FUNCTIONS_LOADED')) {
-	include dirname(__FILE__) . '/functions.php';
+	include __DIR__ . '/functions.php';
 }
 
 /**
@@ -78,7 +78,7 @@ class Smarty_Autoloader
      */
     public static function register($prepend = false)
     {
-        self::$SMARTY_DIR = defined('SMARTY_DIR') ? SMARTY_DIR : dirname(__FILE__) . DIRECTORY_SEPARATOR;
+        self::$SMARTY_DIR = defined('SMARTY_DIR') ? SMARTY_DIR : __DIR__ . DIRECTORY_SEPARATOR;
         self::$SMARTY_SYSPLUGINS_DIR = defined('SMARTY_SYSPLUGINS_DIR') ? SMARTY_SYSPLUGINS_DIR :
             self::$SMARTY_DIR . 'sysplugins' . DIRECTORY_SEPARATOR;
         spl_autoload_register(array(__CLASS__, 'autoload'), true, $prepend);

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -36,7 +36,7 @@ if (!defined('SMARTY_DIR')) {
     /**
      *
      */
-    define('SMARTY_DIR', dirname(__FILE__) . DIRECTORY_SEPARATOR);
+    define('SMARTY_DIR', __DIR__ . DIRECTORY_SEPARATOR);
 }
 /**
  * set SMARTY_SYSPLUGINS_DIR to absolute path to Smarty internal plugins.
@@ -65,14 +65,14 @@ if (!defined('SMARTY_MBSTRING')) {
  * Load helper functions
  */
 if (!defined('SMARTY_HELPER_FUNCTIONS_LOADED')) {
-    include dirname(__FILE__) . '/functions.php';
+    include __DIR__ . '/functions.php';
 }
 
 /**
  * Load Smarty_Autoloader
  */
 if (!class_exists('Smarty_Autoloader')) {
-    include dirname(__FILE__) . '/bootstrap.php';
+    include __DIR__ . '/bootstrap.php';
 }
 
 /**

--- a/libs/bootstrap.php
+++ b/libs/bootstrap.php
@@ -11,6 +11,6 @@
  * Load and register Smarty Autoloader
  */
 if (!class_exists('Smarty_Autoloader')) {
-    include dirname(__FILE__) . '/Autoloader.php';
+    include __DIR__ . '/Autoloader.php';
 }
 Smarty_Autoloader::register(true);

--- a/libs/sysplugins/smarty_internal_debug.php
+++ b/libs/sysplugins/smarty_internal_debug.php
@@ -210,7 +210,7 @@ class Smarty_Internal_Debug extends Smarty_Internal_Data
         // copy the working dirs from application
         $debObj->setCompileDir($smarty->getCompileDir());
         // init properties by hand as user may have edited the original Smarty class
-        $debObj->setPluginsDir(is_dir(dirname(__FILE__) . '/../plugins') ? dirname(__FILE__) .
+        $debObj->setPluginsDir(is_dir(__DIR__ . '/../plugins') ? __DIR__ .
                                                                            '/../plugins' : $smarty->getPluginsDir());
         $debObj->force_compile = false;
         $debObj->compile_check = Smarty::COMPILECHECK_ON;
@@ -221,7 +221,7 @@ class Smarty_Internal_Debug extends Smarty_Internal_Data
         $debObj->debugging_ctrl = 'NONE';
         $debObj->error_reporting = E_ALL & ~E_NOTICE;
         $debObj->debug_tpl =
-            isset($smarty->debug_tpl) ? $smarty->debug_tpl : 'file:' . dirname(__FILE__) . '/../debug.tpl';
+            isset($smarty->debug_tpl) ? $smarty->debug_tpl : 'file:' . __DIR__ . '/../debug.tpl';
         $debObj->registered_plugins = array();
         $debObj->registered_resources = array();
         $debObj->registered_filters = array();

--- a/libs/sysplugins/smarty_internal_testinstall.php
+++ b/libs/sysplugins/smarty_internal_testinstall.php
@@ -144,7 +144,7 @@ class Smarty_Internal_TestInstall
         }
         // test if all registered plugins_dir are accessible
         // and if core plugins directory is still registered
-        $_core_plugins_dir = realpath(dirname(__FILE__) . '/../plugins');
+        $_core_plugins_dir = realpath(__DIR__ . '/../plugins');
         $_core_plugins_available = false;
         foreach ($smarty->getPluginsDir() as $plugin_dir) {
             $_plugin_dir = $plugin_dir;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -6,9 +6,9 @@
 /*
  * Smarty PHPUnit Bootstrap
  */
-require_once dirname(__FILE__) . '/Config.php';
-require_once dirname(__FILE__) . '/../vendor/autoload.php';
-require_once dirname(__FILE__) . '/../libs/bootstrap.php';
+require_once __DIR__ . '/Config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../libs/bootstrap.php';
 
 require_once 'PHPUnit_Smarty.php';
 if (!ini_get('date.timezone')) {

--- a/tests/PHPUnit_Smarty.php
+++ b/tests/PHPUnit_Smarty.php
@@ -128,7 +128,7 @@ class PHPUnit_Smarty extends PHPUnit\Framework\TestCase
                     }
                     $s_dir[ $dir ] = true;
                 }
-                $dir = dirname(__FILE__);
+                $dir = __DIR__;
             }
             if (!is_dir($dir . '/templates_c')) {
                 mkdir($dir . '/templates_c');
@@ -145,8 +145,8 @@ class PHPUnit_Smarty extends PHPUnit\Framework\TestCase
         // instance Smarty class
         $this->smarty = new Smarty;
         if (individualFolders != 'true') {
-            $this->smarty->setCompileDir(dirname(__FILE__) . '/templates_c');
-            $this->smarty->setCacheDir(dirname(__FILE__) . '/cache');
+            $this->smarty->setCompileDir(__DIR__ . '/templates_c');
+            $this->smarty->setCacheDir(__DIR__ . '/cache');
         }
 
         $this->getSmartyObj();
@@ -637,10 +637,10 @@ KEY `name` (`name`)
     }
 
     public static function getSmartyPluginsDir(){
-        if (is_dir(dirname(__FILE__) . '/../smarty/libs/plugins')) {
-            return dirname(__FILE__) . '/../smarty/libs/plugins';
-        } else if(is_dir(dirname(__FILE__) . '/../libs/plugins')) {
-            return dirname(__FILE__) . '/../libs/plugins';
+        if (is_dir(__DIR__ . '/../smarty/libs/plugins')) {
+            return __DIR__ . '/../smarty/libs/plugins';
+        } else if(is_dir(__DIR__ . '/../libs/plugins')) {
+            return __DIR__ . '/../libs/plugins';
         }
     }
     /**

--- a/tests/UnitTests/A_0/PathNormalization/PathNormalizationTest.php
+++ b/tests/UnitTests/A_0/PathNormalization/PathNormalizationTest.php
@@ -17,7 +17,7 @@ class PathNormalizationTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testNormalizeToAbsolute() {

--- a/tests/UnitTests/A_0/PathNormalization/PluginDirNormalizationTest.php
+++ b/tests/UnitTests/A_0/PathNormalization/PluginDirNormalizationTest.php
@@ -17,7 +17,7 @@ class PluginNormalizationTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testGetPluginsDefaultDir()

--- a/tests/UnitTests/A_0/PathNormalization/TemlateDirNormalizationTest.php
+++ b/tests/UnitTests/A_0/PathNormalization/TemlateDirNormalizationTest.php
@@ -17,7 +17,7 @@ class TemplateNormalizationTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testGetTemplateDir()

--- a/tests/UnitTests/A_1/ProtectedFolderVars/ProtectedFolderVarsTest.php
+++ b/tests/UnitTests/A_1/ProtectedFolderVars/ProtectedFolderVarsTest.php
@@ -17,7 +17,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /*
@@ -29,7 +29,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->template_dir = './foo';
         $d = $s->getTemplateDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testTemplateDirDirectRelativeArray()
@@ -37,8 +37,8 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->template_dir = array('./foo', './bar/');
         $d = $s->template_dir;
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testTemplateDirDirectRelativeArrayAdd()
@@ -47,15 +47,15 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s->template_dir = './foo';
         $s->addTemplateDir('./bar/');
         $d = $s->getTemplateDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testTemplateDirDirectRelativeExtends()
     {
         $s = new FolderT();
         $d = $s->getTemplateDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testTemplateDirDirectRelativeExtends2()
@@ -63,7 +63,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new FolderT();
         $s->template_dir = './bar';
         $d = $s->getTemplateDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     /*
@@ -75,7 +75,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->config_dir = './foo';
         $d = $s->getConfigDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testConfigDirDirectRelativeArray()
@@ -83,8 +83,8 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->config_dir = array('./foo', './bar/');
         $d = $s->config_dir;
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testConfigDirDirectRelativeArrayAdd()
@@ -93,15 +93,15 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s->config_dir = './foo';
         $s->addConfigDir('./bar/');
         $d = $s->getConfigDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testConfigDirDirectRelativeExtends()
     {
         $s = new FolderT();
         $d = $s->getConfigDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testConfigDirDirectRelativeExtends2()
@@ -109,7 +109,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new FolderT();
         $s->config_dir = './bar';
         $d = $s->getConfigDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     /*
@@ -121,7 +121,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->plugins_dir = './foo';
         $d = $s->getPluginsDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testPluginDirDirectRelativeArray()
@@ -129,8 +129,8 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->plugins_dir = array('./foo', './bar/');
         $d = $s->plugins_dir;
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testPluginDirDirectRelativeArrayAdd()
@@ -139,15 +139,15 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s->plugins_dir = './foo';
         $s->addPluginsDir('./bar/');
         $d = $s->getPluginsDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 1 ]);
     }
 
     public function testPluginDirDirectRelativeExtends()
     {
         $s = new FolderT();
         $d = $s->getPluginsDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'plug' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'plug' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
 
     public function testPluginDirDirectRelativeExtends2()
@@ -155,7 +155,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new FolderT();
         $s->plugins_dir = './bar';
         $d = $s->getPluginsDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d[ 0 ]);
     }
     /*
      * compile_dir
@@ -166,14 +166,14 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->compile_dir = './foo';
         $d = $s->getCompileDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d);
     }
 
     public function testCompileDirDirectRelativeExtends()
     {
         $s = new FolderT();
         $d = $s->getCompileDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'comp' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'comp' . DIRECTORY_SEPARATOR, $d);
     }
 
     public function testCompileDirDirectRelativeExtends2()
@@ -181,7 +181,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new FolderT();
         $s->compile_dir = './bar';
         $d = $s->getCompileDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d);
     }
     /*
      * cache_dir
@@ -192,14 +192,14 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new Smarty();
         $s->cache_dir = './foo';
         $d = $s->getCacheDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR, $d);
     }
 
     public function testCacheDirDirectRelativeExtends()
     {
         $s = new FolderT();
         $d = $s->getCacheDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR, $d);
     }
 
     public function testCacheDirDirectRelativeExtends2()
@@ -207,7 +207,7 @@ class ProtectedFolderVarsTest extends PHPUnit_Smarty
         $s = new FolderT();
         $s->cache_dir = './bar';
         $d = $s->getCacheDir();
-        $this->assertEquals(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d);
+        $this->assertEquals(__DIR__ . DIRECTORY_SEPARATOR . 'bar' . DIRECTORY_SEPARATOR, $d);
     }
 }
 

--- a/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
+++ b/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
@@ -15,7 +15,7 @@ class UndefinedTemplateVarTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/A_Core/AutoEscape/AutoEscapeTest.php
+++ b/tests/UnitTests/A_Core/AutoEscape/AutoEscapeTest.php
@@ -17,7 +17,7 @@ class AutoEscapeTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setEscapeHtml(true);
     }
 

--- a/tests/UnitTests/A_Core/Filter/FilterTest.php
+++ b/tests/UnitTests/A_Core/Filter/FilterTest.php
@@ -18,7 +18,7 @@ class FilterTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/A_Core/Filter/LoadFilterTest.php
+++ b/tests/UnitTests/A_Core/Filter/LoadFilterTest.php
@@ -17,7 +17,7 @@ class LoadFilterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/A_Core/Filter/RegisterFilterTest.php
+++ b/tests/UnitTests/A_Core/Filter/RegisterFilterTest.php
@@ -17,7 +17,7 @@ class RegisterFilterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/A_Core/GetterSetter/GetterSetterTest.php
+++ b/tests/UnitTests/A_Core/GetterSetter/GetterSetterTest.php
@@ -17,7 +17,7 @@ class GetterSetterTest extends PHPUnit_Smarty
 {
      public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/A_Core/LoadPlugin/DefaultPluginHandlerTest.php
+++ b/tests/UnitTests/A_Core/LoadPlugin/DefaultPluginHandlerTest.php
@@ -17,7 +17,7 @@ class DefaultPluginHandlerTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setForceCompile(true);
         $this->smarty->disableSecurity();
         $this->smarty->registerDefaultPluginHandler('my_plugin_handler');

--- a/tests/UnitTests/A_Core/LoadPlugin/IncludePathTest.php
+++ b/tests/UnitTests/A_Core/LoadPlugin/IncludePathTest.php
@@ -13,12 +13,12 @@ class IncludePathTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->use_include_path = true;
         $this->smarty->setPluginsDir(array('./include','./include1'));
         $this->smarty->enableSecurity();
         $ds = DIRECTORY_SEPARATOR;
-        set_include_path($this->smarty->_realpath(dirname(__FILE__) . "{$ds}..{$ds}..{$ds}..{$ds}Include_Path{$ds}Plugins{$ds}", true) . PATH_SEPARATOR . get_include_path());
+        set_include_path($this->smarty->_realpath(__DIR__ . "{$ds}..{$ds}..{$ds}..{$ds}Include_Path{$ds}Plugins{$ds}", true) . PATH_SEPARATOR . get_include_path());
     }
 
     /**

--- a/tests/UnitTests/A_Core/LoadPlugin/LoadPluginTest.php
+++ b/tests/UnitTests/A_Core/LoadPlugin/LoadPluginTest.php
@@ -17,7 +17,7 @@ class LoadPluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/A_Core/PluginTests/PluginChainedLoadTest.php
+++ b/tests/UnitTests/A_Core/PluginTests/PluginChainedLoadTest.php
@@ -17,7 +17,7 @@ class PluginChainedLoadTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()
@@ -27,7 +27,7 @@ class PluginChainedLoadTest extends PHPUnit_Smarty
 
     public function testPluginChainedLoad()
     {
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         $this->assertStringContainsString('from chain3', $this->smarty->fetch('test_plugin_chained_load.tpl'));
     }
 }

--- a/tests/UnitTests/A_Core/PluginTests/Shared/SharedFunctionsTest.php
+++ b/tests/UnitTests/A_Core/PluginTests/Shared/SharedFunctionsTest.php
@@ -13,7 +13,7 @@ class SharedFunctionsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/CacheModify/ModifiedSince/HttpModifiedSinceTest.php
+++ b/tests/UnitTests/CacheModify/ModifiedSince/HttpModifiedSinceTest.php
@@ -18,7 +18,7 @@ class HttpModifiedSinceTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
      }
 
     public function testInit()

--- a/tests/UnitTests/CacheResourceTests/Apc/CacheResourceCustomApcTest.php
+++ b/tests/UnitTests/CacheResourceTests/Apc/CacheResourceCustomApcTest.php
@@ -5,7 +5,7 @@
  * @package PHPunit
  * @author  Uwe Tews
  */
-include_once dirname(__FILE__) . '/../Memcache/CacheResourceCustomMemcacheTest.php';
+include_once __DIR__ . '/../Memcache/CacheResourceCustomMemcacheTest.php';
 
 /**
  * class for cache resource file tests
@@ -21,7 +21,7 @@ class CacheResourceCustomApcTest extends CacheResourceCustomMemcacheTest
         if (!function_exists('apc_cache_info') || ini_get('apc.enable_cli')) {
             $this->markTestSkipped('APC cache not available');
         }
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         parent::setUp();
         $this->smarty->setCachingType('apc');
         $this->smarty->addPluginsDir(SMARTY_DIR . '../demo/plugins/');

--- a/tests/UnitTests/CacheResourceTests/File/CacheResourceFileTest.php
+++ b/tests/UnitTests/CacheResourceTests/File/CacheResourceFileTest.php
@@ -6,7 +6,7 @@
  * @author  Uwe Tews
  */
 
-include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
 /**
  * class for cache resource file tests
@@ -20,7 +20,7 @@ class CacheResourceFileTest extends CacheResourceTestCommon
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         parent::setUp();
         $this->smarty->setCachingType('filetest');
     }

--- a/tests/UnitTests/CacheResourceTests/Memcache/CacheResourceCustomMemcacheTest.php
+++ b/tests/UnitTests/CacheResourceTests/Memcache/CacheResourceCustomMemcacheTest.php
@@ -6,7 +6,7 @@
  * @author  Uwe Tews
  */
 
-include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
 /**
  * class for cache resource memcache tests
@@ -27,7 +27,7 @@ class CacheResourceCustomMemcacheTest extends CacheResourceTestCommon
         if (!class_exists('Memcache')) {
             $this->markTestSkipped('Memcache not available');
         }
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         parent::setUp();
         $this->smarty->setCachingType('memcachetest');
     }

--- a/tests/UnitTests/CacheResourceTests/Mysql/CacheResourceCustomMysqlTest.php
+++ b/tests/UnitTests/CacheResourceTests/Mysql/CacheResourceCustomMysqlTest.php
@@ -7,7 +7,7 @@
  */
 if (MysqlCacheEnable == true) {
 
-    include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+    include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
     /**
      * class for cache resource file tests
@@ -28,7 +28,7 @@ if (MysqlCacheEnable == true) {
             if (self::$init) {
                 $this->getConnection();
             }
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
             parent::setUp();
             $this->smarty->setCachingType('mysqltest');
         }

--- a/tests/UnitTests/CacheResourceTests/PDO/CacheResourceCustomPDOTest.php
+++ b/tests/UnitTests/CacheResourceTests/PDO/CacheResourceCustomPDOTest.php
@@ -7,7 +7,7 @@
  */
 if (PdoCacheEnable == true) {
 
-    include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+    include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
     /**
      * class for cache resource file tests
@@ -27,7 +27,7 @@ if (PdoCacheEnable == true) {
             if (self::$init) {
                 $this->getConnection();
             }
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
             parent::setUp();
             $this->smarty->setCachingType('pdo');
             $this->smarty->addPluginsDir(SMARTY_DIR . '../demo/plugins/');

--- a/tests/UnitTests/CacheResourceTests/PDOgzip/CacheResourceCustomPDOGzipTest.php
+++ b/tests/UnitTests/CacheResourceTests/PDOgzip/CacheResourceCustomPDOGzipTest.php
@@ -7,7 +7,7 @@
  */
 if (PdoGzipCacheEnable == true) {
 
-    include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+    include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
     /**
      * class for cache resource file tests
@@ -25,7 +25,7 @@ if (PdoGzipCacheEnable == true) {
             if (self::$init) {
                 $this->getConnection();
             }
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
             parent::setUp();
             $this->smarty->setCachingType('pdo');
             $this->smarty->addPluginsDir(SMARTY_DIR . '../demo/plugins/');

--- a/tests/UnitTests/CacheResourceTests/Registered/CacheResourceCustomRegisteredTest.php
+++ b/tests/UnitTests/CacheResourceTests/Registered/CacheResourceCustomRegisteredTest.php
@@ -6,7 +6,7 @@
  * @author  Uwe Tews
  */
 if (MysqlCacheEnable == true) {
-    include_once dirname(__FILE__) . '/../_shared/CacheResourceTestCommon.php';
+    include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 
     /**
      * class for cache resource file tests
@@ -25,10 +25,10 @@ if (MysqlCacheEnable == true) {
             if (self::$init) {
                 $this->getConnection();
             }
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
             parent::setUp();
             if (!class_exists('Smarty_CacheResource_Mysqltest', false)) {
-                require_once(dirname(__FILE__) . "/../_shared/PHPunitplugins/cacheresource.mysqltest.php");
+                require_once(__DIR__ . "/../_shared/PHPunitplugins/cacheresource.mysqltest.php");
             }
             $this->smarty->setCachingType('foobar');
             $this->smarty->registerCacheResource('foobar', new Smarty_CacheResource_Mysqltest());

--- a/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
@@ -17,8 +17,8 @@ class CacheResourceTestCommon extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->smarty->setTemplateDir(dirname(__FILE__) . '/templates');
-        $this->smarty->addPluginsDir(dirname(__FILE__) . '/PHPunitplugins');
+        $this->smarty->setTemplateDir(__DIR__ . '/templates');
+        $this->smarty->addPluginsDir(__DIR__ . '/PHPunitplugins');
         $this->smarty->registerFilter('pre', array($this, 'compiledPrefilter'));
     }
 
@@ -543,9 +543,9 @@ class CacheResourceTestCommon extends PHPUnit_Smarty
     {
         $this->smarty->setCaching(true);
         if ($folder == 0) {
-            $this->smarty->setTemplateDir(array(dirname(__FILE__) . '/../_shared/templates', dirname(__FILE__) . '/../_shared/templates/a'));
+            $this->smarty->setTemplateDir(array(__DIR__ . '/../_shared/templates', __DIR__ . '/../_shared/templates/a'));
         } else {
-            $this->smarty->setTemplateDir(array(dirname(__FILE__) . '/../_shared/templates', dirname(__FILE__) . '/../_shared/templates/b'));
+            $this->smarty->setTemplateDir(array(__DIR__ . '/../_shared/templates', __DIR__ . '/../_shared/templates/b'));
         }
         if ($merge) {
             $this->smarty->setCompileId(1);

--- a/tests/UnitTests/Compiler/CompilerPlugin/CompileCompilerPluginTest.php
+++ b/tests/UnitTests/Compiler/CompilerPlugin/CompileCompilerPluginTest.php
@@ -17,7 +17,7 @@ class CompileCompilerPluginTest extends PHPUnit_Smarty
 {
      public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/Compiler/Delimiter/AutoLiteralTest.php
+++ b/tests/UnitTests/Compiler/Delimiter/AutoLiteralTest.php
@@ -16,7 +16,7 @@ class AutoliteralTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../__shared/PHPunitplugins/");
     }
 

--- a/tests/UnitTests/Compiler/Delimiter/DelimiterTest.php
+++ b/tests/UnitTests/Compiler/Delimiter/DelimiterTest.php
@@ -17,7 +17,7 @@ class DelimiterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/Compiler/Delimiter/UserLiteralTest.php
+++ b/tests/UnitTests/Compiler/Delimiter/UserLiteralTest.php
@@ -20,7 +20,7 @@ class UserliteralTest extends PHPUnit_Smarty
         if (!property_exists('Smarty', 'literals')) {
             $this->markTestSkipped('user literal support');
         } else {
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
         }
     }
 

--- a/tests/UnitTests/ConfigFileTests/defaultHandler/DefaultConfigHandlerTest.php
+++ b/tests/UnitTests/ConfigFileTests/defaultHandler/DefaultConfigHandlerTest.php
@@ -23,7 +23,7 @@ class DefaultConfigHandlerTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setForceCompile(true);
     }
 

--- a/tests/UnitTests/ConfigFileTests/file/ConfigVarTest.php
+++ b/tests/UnitTests/ConfigFileTests/file/ConfigVarTest.php
@@ -22,7 +22,7 @@ class ConfigVarTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**
@@ -387,7 +387,7 @@ class ConfigVarTest extends PHPUnit_Smarty
 
     public function testConfigResourceDb4()
     {
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         $this->smarty->configLoad('db4:foo.conf');
         $this->assertEquals("bar", $this->smarty->fetch('foo.tpl'));
     }

--- a/tests/UnitTests/ResourceTests/Custom/Ambiguous/CustomResourceAmbiguousTest.php
+++ b/tests/UnitTests/ResourceTests/Custom/Ambiguous/CustomResourceAmbiguousTest.php
@@ -19,8 +19,8 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
-        require_once dirname(__FILE__) . '/PHPunitplugins/resource.ambiguous.php';
+        $this->setUpSmarty(__DIR__);
+        require_once __DIR__ . '/PHPunitplugins/resource.ambiguous.php';
 
         // empty the template dir
         $this->smarty->setTemplateDir(array());
@@ -36,7 +36,7 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
 
     protected function relative($path)
     {
-        $path = str_replace(dirname(__FILE__), '.', $path);
+        $path = str_replace(__DIR__, '.', $path);
         if (DIRECTORY_SEPARATOR == "\\") {
             $path = str_replace("\\", "/", $path);
         }
@@ -46,7 +46,7 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
 
     public function testNone()
     {
-        $resource_handler = new Smarty_Resource_Ambiguous(dirname(__FILE__) . '/templates/ambiguous/');
+        $resource_handler = new Smarty_Resource_Ambiguous(__DIR__ . '/templates/ambiguous/');
         $this->smarty->registerResource('ambiguous', $resource_handler);
         $this->smarty->setDefaultResourceType('ambiguous');
         $this->smarty->setAllowAmbiguousResources(true);
@@ -63,7 +63,7 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
      */
     public function testCase1()
     {
-        $resource_handler = new Smarty_Resource_Ambiguous(dirname(__FILE__) . '/templates/ambiguous/');
+        $resource_handler = new Smarty_Resource_Ambiguous(__DIR__ . '/templates/ambiguous/');
         $this->smarty->registerResource('ambiguous', $resource_handler);
         $this->smarty->setDefaultResourceType('ambiguous');
         $this->smarty->setAllowAmbiguousResources(true);
@@ -83,7 +83,7 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
      */
     public function testCase2()
     {
-        $resource_handler = new Smarty_Resource_Ambiguous(dirname(__FILE__) . '/templates/ambiguous/');
+        $resource_handler = new Smarty_Resource_Ambiguous(__DIR__ . '/templates/ambiguous/');
         $this->smarty->registerResource('ambiguous', $resource_handler);
         $this->smarty->setDefaultResourceType('ambiguous');
         $this->smarty->setAllowAmbiguousResources(true);
@@ -103,7 +103,7 @@ class CustomResourceAmbiguousTest extends PHPUnit_Smarty
      */
     public function testCaseSwitching()
     {
-        $resource_handler = new Smarty_Resource_Ambiguous(dirname(__FILE__) . '/templates/ambiguous/');
+        $resource_handler = new Smarty_Resource_Ambiguous(__DIR__ . '/templates/ambiguous/');
         $this->smarty->registerResource('ambiguous', $resource_handler);
         $this->smarty->setDefaultResourceType('ambiguous');
         $this->smarty->setAllowAmbiguousResources(true);

--- a/tests/UnitTests/ResourceTests/Custom/DemoPluginExtendsAll/ResourceExtendsAllPluginTest.php
+++ b/tests/UnitTests/ResourceTests/Custom/DemoPluginExtendsAll/ResourceExtendsAllPluginTest.php
@@ -17,7 +17,7 @@ class ResourceExtendsAllPluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/ResourceTests/Custom/DemoPluginMysql/ResourceMysqlPluginTest.php
+++ b/tests/UnitTests/ResourceTests/Custom/DemoPluginMysql/ResourceMysqlPluginTest.php
@@ -23,7 +23,7 @@ if (MysqlResourceEnable == true) {
                 if (self::$init) {
                 $this->getConnection();
             }
-            $this->setUpSmarty(dirname(__FILE__));
+            $this->setUpSmarty(__DIR__);
             $this->smarty->addPluginsDir("./PHPunitplugins/");
         }
 

--- a/tests/UnitTests/ResourceTests/DefaultHandler/DefaultTemplateHandlerTest.php
+++ b/tests/UnitTests/ResourceTests/DefaultHandler/DefaultTemplateHandlerTest.php
@@ -17,7 +17,7 @@ class DefaultTemplateHandlerTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setForceCompile(true);
         $this->smarty->disableSecurity();
     }

--- a/tests/UnitTests/ResourceTests/Eval/EvalResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Eval/EvalResourceTest.php
@@ -17,7 +17,7 @@ class EvalResourceTest extends PHPUnit_Smarty
 {
    public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/ResourceTests/Extends/ExtendsResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Extends/ExtendsResourceTest.php
@@ -17,7 +17,7 @@ class ExtendsResourceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->enableSecurity();
     }
 

--- a/tests/UnitTests/ResourceTests/File/FileResourceTest.php
+++ b/tests/UnitTests/ResourceTests/File/FileResourceTest.php
@@ -17,7 +17,7 @@ class FileResourceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->enableSecurity();
     }
 
@@ -28,7 +28,7 @@ class FileResourceTest extends PHPUnit_Smarty
 
     protected function relative($path)
     {
-        $path = str_replace(str_replace("\\", "/", dirname(__FILE__)), '.', str_replace("\\", "/", $path));
+        $path = str_replace(str_replace("\\", "/", __DIR__), '.', str_replace("\\", "/", $path));
 
         return $path;
     }
@@ -249,8 +249,8 @@ class FileResourceTest extends PHPUnit_Smarty
     public function testRelativeFetch()
     {
         $this->smarty->setTemplateDir(array(
-                                          dirname(__FILE__) . '/does-not-exist/',
-                                          dirname(__FILE__) . '/templates/sub/',
+                                          __DIR__ . '/does-not-exist/',
+                                          __DIR__ . '/templates/sub/',
                                       ));
         $this->smarty->security_policy = null;
         $this->assertEquals('hello world', $this->smarty->fetch('./relative.tpl'));
@@ -265,8 +265,8 @@ class FileResourceTest extends PHPUnit_Smarty
     public function testRelativeFetch2()
     {
          $this->smarty->setTemplateDir(array(
-                                          dirname(__FILE__) . '/does-not-exist/',
-                                          dirname(__FILE__) . '/templates/sub/',
+                                          __DIR__ . '/does-not-exist/',
+                                          __DIR__ . '/templates/sub/',
                                       ));
         $this->smarty->security_policy = null;
         $this->assertEquals('hello world', $this->smarty->fetch('../helloworld.tpl'));
@@ -281,12 +281,12 @@ class FileResourceTest extends PHPUnit_Smarty
     public function testRelativeFetchCwd()
     {
         $cwd = getcwd();
-        chdir(dirname(__FILE__) . '/templates/sub/');
-        $dn = dirname(__FILE__);
+        chdir(__DIR__ . '/templates/sub/');
+        $dn = __DIR__;
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
         $this->smarty->setTemplateDir(array(
-                                          dirname(__FILE__) . '/does-not-exist/',
+                                          __DIR__ . '/does-not-exist/',
                                       ));
         $this->smarty->security_policy = null;
         $this->assertEquals('hello world', $this->smarty->fetch('./relative.tpl'));
@@ -302,12 +302,12 @@ class FileResourceTest extends PHPUnit_Smarty
     public function testRelativeFetchCwd2()
     {
         $cwd = getcwd();
-        chdir(dirname(__FILE__) . '/templates/sub/');
-        $dn = dirname(__FILE__);
+        chdir(__DIR__ . '/templates/sub/');
+        $dn = __DIR__;
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
         $this->smarty->setTemplateDir(array(
-                                          dirname(__FILE__) . '/does-not-exist/',
+                                          __DIR__ . '/does-not-exist/',
                                       ));
         $this->smarty->security_policy = null;
         $this->assertEquals('hello world', $this->smarty->fetch('../helloworld.tpl'));
@@ -359,7 +359,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
         $this->smarty->setTemplateDir(array($dn . '/templates/relativity/theory/',));
@@ -378,7 +378,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
 
@@ -409,7 +409,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -438,7 +438,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -458,7 +458,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -489,7 +489,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -507,7 +507,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -526,7 +526,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
 
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
@@ -560,7 +560,7 @@ class FileResourceTest extends PHPUnit_Smarty
         $this->smarty->security_policy = null;
 
         $cwd = getcwd();
-        $dn = dirname(__FILE__);
+        $dn = __DIR__;
         $this->smarty->setCompileDir($dn . '/templates_c/');
         $this->smarty->setCacheDir($dn . '/cache/');
         $this->smarty->setTemplateDir(array(
@@ -599,7 +599,7 @@ class FileResourceTest extends PHPUnit_Smarty
      *
      */
     public function testSmartyCurrentDir() {
-        $dirname = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'templates';
+        $dirname = __DIR__ . DIRECTORY_SEPARATOR . 'templates';
         $this->assertEquals('current_dir = ' . $dirname, $this->smarty->fetch('001_smarty_current_dir.tpl'));
     }
 }

--- a/tests/UnitTests/ResourceTests/FileIncludePath/FileIncludePathTest.php
+++ b/tests/UnitTests/ResourceTests/FileIncludePath/FileIncludePathTest.php
@@ -13,12 +13,12 @@ class FileIncludePathTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->use_include_path = true;
         $this->smarty->setTemplateDir(array('./templates', './templates_2', './include'));
         $this->smarty->enableSecurity();
         $ds = DIRECTORY_SEPARATOR;
-        set_include_path($this->smarty->_realpath(dirname(__FILE__) . "{$ds}..{$ds}..{$ds}..{$ds}Include_Path{$ds}Tpl{$ds}", true) . PATH_SEPARATOR . get_include_path());
+        set_include_path($this->smarty->_realpath(__DIR__ . "{$ds}..{$ds}..{$ds}..{$ds}Include_Path{$ds}Tpl{$ds}", true) . PATH_SEPARATOR . get_include_path());
     }
 
     /**

--- a/tests/UnitTests/ResourceTests/FileIndexed/FileResourceIndexedTest.php
+++ b/tests/UnitTests/ResourceTests/FileIndexed/FileResourceIndexedTest.php
@@ -13,11 +13,11 @@ class FileResourceIndexedTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
-        $this->smarty->addTemplateDir(dirname(__FILE__) . '/templates_2');
+        $this->setUpSmarty(__DIR__);
+        $this->smarty->addTemplateDir(__DIR__ . '/templates_2');
         // note that 10 is a string!
-        $this->smarty->addTemplateDir(dirname(__FILE__) . '/templates_3', '10');
-        $this->smarty->addTemplateDir(dirname(__FILE__) . '/templates_4', 'foo');
+        $this->smarty->addTemplateDir(__DIR__ . '/templates_3', '10');
+        $this->smarty->addTemplateDir(__DIR__ . '/templates_4', 'foo');
      }
 
     public function testInit()

--- a/tests/UnitTests/ResourceTests/Php/PhpResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Php/PhpResourceTest.php
@@ -17,7 +17,7 @@ class PhpResourceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()
@@ -27,7 +27,7 @@ class PhpResourceTest extends PHPUnit_Smarty
 
     protected function relative($path)
     {
-        $path = str_replace(str_replace("\\", "/", dirname(__FILE__)), '.', str_replace("\\", "/", $path));
+        $path = str_replace(str_replace("\\", "/", __DIR__), '.', str_replace("\\", "/", $path));
 
         return $path;
     }

--- a/tests/UnitTests/ResourceTests/Registered/RegisteredResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Registered/RegisteredResourceTest.php
@@ -18,7 +18,7 @@ class RegisteredResourceTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         $this->smarty->registerResource("rr", new RegisteredResourceTest_Resource1());
     }

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/ResourcePluginTest.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/ResourcePluginTest.php
@@ -17,7 +17,7 @@ class ResourcePluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-          $this->setUpSmarty(dirname(__FILE__));
+          $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/ResourceTests/Stream/StreamResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Stream/StreamResourceTest.php
@@ -17,7 +17,7 @@ class StreamResourceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         $this->smarty->assign('foo', 'bar');
         stream_wrapper_register("global", "ResourceStream")

--- a/tests/UnitTests/ResourceTests/String/StringResourceTest.php
+++ b/tests/UnitTests/ResourceTests/String/StringResourceTest.php
@@ -17,7 +17,7 @@ class StringResourceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 
@@ -28,7 +28,7 @@ class StringResourceTest extends PHPUnit_Smarty
 
     protected function relative($path)
     {
-        $path = str_replace(dirname(__FILE__), '.', $path);
+        $path = str_replace(__DIR__, '.', $path);
         if (DIRECTORY_SEPARATOR == "\\") {
             $path = str_replace("\\", "/", $path);
         }

--- a/tests/UnitTests/SecurityTests/FunctionTest.php
+++ b/tests/UnitTests/SecurityTests/FunctionTest.php
@@ -17,7 +17,7 @@ class FunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -17,7 +17,7 @@ class SecurityTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         $this->smarty->setForceCompile(true);
         $this->smarty->enableSecurity();
@@ -237,7 +237,7 @@ class SecurityTest extends PHPUnit_Smarty
     {
         $this->expectException('SmartyException');
         $this->expectExceptionMessage('not trusted file path');
-        $this->smarty->security_policy->secure_dir = array(str_replace('\\', '/', dirname(__FILE__) . '/templates_3/'));
+        $this->smarty->security_policy->secure_dir = array(str_replace('\\', '/', __DIR__ . '/templates_3/'));
         $this->smarty->fetch('string:{include file="templates_2/hello.tpl"}');
      }
 

--- a/tests/UnitTests/SmartyMethodsTests/Append/AppendTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/Append/AppendTest.php
@@ -17,7 +17,7 @@ class AppendTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/AppendByRef/AppendByRefTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/AppendByRef/AppendByRefTest.php
@@ -17,7 +17,7 @@ class AppendByRefTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/SmartyMethodsTests/Assign/AssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/Assign/AssignTest.php
@@ -17,7 +17,7 @@ class AssignTest extends PHPUnit_Smarty
 {
      public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/AssignByRef/AssignByRefTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/AssignByRef/AssignByRefTest.php
@@ -17,7 +17,7 @@ class AssignByRefTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     /**

--- a/tests/UnitTests/SmartyMethodsTests/AssignGlobal/AssignGlobalTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/AssignGlobal/AssignGlobalTest.php
@@ -17,7 +17,7 @@ class AssignGlobalTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignTest.php
@@ -20,7 +20,7 @@ class ClearAllAssignTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         $this->smarty->assign('foo', 'foo');
         $this->_data = $this->smarty->createData($this->smarty);

--- a/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignTest.php
@@ -17,7 +17,7 @@ class ClearAssignTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->assign('foo', 'foo');
         $this->smarty->assign('bar', 'bar');
         $this->smarty->assign('blar', 'blar');

--- a/tests/UnitTests/SmartyMethodsTests/ClearCompiledTemplate/ClearCompiledTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearCompiledTemplate/ClearCompiledTest.php
@@ -19,7 +19,7 @@ class ClearCompiledTest extends PHPUnit_Smarty
     public $methodName = null;
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addTemplateDir('./templates_2/');
         $this->methodName = 'clearCompiledTemplate';
     }

--- a/tests/UnitTests/SmartyMethodsTests/GetTemplateVars/GetTemplateVarsTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/GetTemplateVars/GetTemplateVarsTest.php
@@ -17,7 +17,7 @@ class GetTemplateVarsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/RegisterBlock/RegisterBlockTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterBlock/RegisterBlockTest.php
@@ -17,7 +17,7 @@ class RegisterBlockTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->disableSecurity();
     }
 

--- a/tests/UnitTests/SmartyMethodsTests/RegisterCompiler/RegisterCompilerFunctionTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterCompiler/RegisterCompilerFunctionTest.php
@@ -17,7 +17,7 @@ class RegisterCompilerFunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/RegisterFunction/RegisterFunctionTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterFunction/RegisterFunctionTest.php
@@ -18,7 +18,7 @@ class RegisterFunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/SmartyMethodsTests/RegisterModifier/RegisterModifierTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterModifier/RegisterModifierTest.php
@@ -17,7 +17,7 @@ class RegisterModifierTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/SmartyMethodsTests/RegisterObject/CompileRegisteredObjectFunctionTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterObject/CompileRegisteredObjectFunctionTest.php
@@ -17,7 +17,7 @@ class CompileRegisteredObjectFunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         $this->smarty->setForceCompile(true);
         $this->smarty->disableSecurity();

--- a/tests/UnitTests/SmartyMethodsTests/TemplateExist/TemplateExistsTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/TemplateExist/TemplateExistsTest.php
@@ -17,7 +17,7 @@ class TemplateExistsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/Comments/CommentsTest.php
+++ b/tests/UnitTests/TemplateSource/Comments/CommentsTest.php
@@ -17,7 +17,7 @@ class CommentsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/Spacing/SpacingTest.php
+++ b/tests/UnitTests/TemplateSource/Spacing/SpacingTest.php
@@ -17,7 +17,7 @@ class SpacingTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/StaticClass/StaticClassAccessTest.php
+++ b/tests/UnitTests/TemplateSource/StaticClass/StaticClassAccessTest.php
@@ -17,7 +17,7 @@ class StaticClassAccessTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->disableSecurity();
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/Append/CompileAppendTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Append/CompileAppendTest.php
@@ -17,7 +17,7 @@ class CompileAppendTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/TagTests/Assign/CompileAssignTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Assign/CompileAssignTest.php
@@ -17,7 +17,7 @@ class CompileAssignTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/TagTests/BlockPlugin/CompileBlockPluginTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/BlockPlugin/CompileBlockPluginTest.php
@@ -17,7 +17,7 @@ class CompileBlockPluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("./PHPunitplugins/");
         $this->smarty->disableSecurity();
     }

--- a/tests/UnitTests/TemplateSource/TagTests/BockExtend/CompileBlockExtendsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/BockExtend/CompileBlockExtendsTest.php
@@ -17,7 +17,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         //$this->smarty->setMergeCompiledIncludes(true);
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/Capture/CompileCaptureTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Capture/CompileCaptureTest.php
@@ -17,7 +17,7 @@ class CompileCaptureTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addTemplateDir("./templates_tmp");
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/CompilerPlugin/CompilerPluginTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/CompilerPlugin/CompilerPluginTest.php
@@ -17,7 +17,7 @@ class CompilerPluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 
@@ -30,7 +30,7 @@ class CompilerPluginTest extends PHPUnit_Smarty
      */
     public function testCompilerPlugin()
     {
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         $this->assertEquals('test output', $this->smarty->fetch('eval:{test data="test output"}{/test}'));
     }
 }

--- a/tests/UnitTests/TemplateSource/TagTests/ConfigLoad/CompileConfigLoadTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/ConfigLoad/CompileConfigLoadTest.php
@@ -22,7 +22,7 @@ class CompileConfigLoadTest extends PHPUnit_Smarty
      */
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/TagTests/Delimiter/CompileDelimiterTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Delimiter/CompileDelimiterTest.php
@@ -17,7 +17,7 @@ class CompileDelimiterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/Eval/CompileEvalTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Eval/CompileEvalTest.php
@@ -17,7 +17,7 @@ class CompileEvalTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/For/CompileForTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/For/CompileForTest.php
@@ -17,7 +17,7 @@ class CompileForTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/Foreach/CompileForeachTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Foreach/CompileForeachTest.php
@@ -17,7 +17,7 @@ class CompileForeachTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("./templates_tmp");
     }

--- a/tests/UnitTests/TemplateSource/TagTests/FunctionPlugin/CompileFunctionPluginTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/FunctionPlugin/CompileFunctionPluginTest.php
@@ -17,7 +17,7 @@ class CompileFunctionPluginTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/If/CompileIfTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/If/CompileIfTest.php
@@ -17,7 +17,7 @@ class CompileIfTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/TagTests/Include/CompileIncludeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Include/CompileIncludeTest.php
@@ -17,7 +17,7 @@ class CompileIncludeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("./templates_tmp");
     }

--- a/tests/UnitTests/TemplateSource/TagTests/Insert/CompileInsertTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Insert/CompileInsertTest.php
@@ -17,8 +17,8 @@ class CompileInsertTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->setUpSmarty(__DIR__);
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         $this->smarty->enableSecurity();
     }
 
@@ -120,7 +120,7 @@ class CompileInsertTest extends PHPUnit_Smarty
      */
     public function testInsertPluginCaching1_2()
     {
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         global $insertglobal;
         $insertglobal = 'changed global 2';
         $this->smarty->caching = 1;
@@ -138,7 +138,7 @@ class CompileInsertTest extends PHPUnit_Smarty
      */
     public function testInsertPluginCaching1_3()
     {
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
         global $insertglobal;
         $insertglobal = 'changed global';
         $this->smarty->caching = 1;
@@ -156,7 +156,7 @@ class CompileInsertTest extends PHPUnit_Smarty
     public function testInsertPluginCaching1_4()
     {
         global $insertglobal;
-        $this->smarty->addPluginsDir(dirname(__FILE__) . "/PHPunitplugins/");
+        $this->smarty->addPluginsDir(__DIR__ . "/PHPunitplugins/");
             $insertglobal = 'changed global 4';
             $this->smarty->caching = 1;
             $this->smarty->assign('foo', 'buh', true);

--- a/tests/UnitTests/TemplateSource/TagTests/Literal/LiteralTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Literal/LiteralTest.php
@@ -17,7 +17,7 @@ class LiteralTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/MakeNocache/CompileMakeNocacheTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/MakeNocache/CompileMakeNocacheTest.php
@@ -17,7 +17,7 @@ class CompileMakeNocacheTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/TagTests/Nocache/CompileNocacheTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Nocache/CompileNocacheTest.php
@@ -17,7 +17,7 @@ class CompileNocacheTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/PluginBlock/PluginBlockTextformatTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginBlock/PluginBlockTextformatTest.php
@@ -19,7 +19,7 @@ class PluginBlockTextformatTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionFetchTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionFetchTest.php
@@ -17,7 +17,7 @@ class PluginFunctionFetchTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlCheckboxesTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlCheckboxesTest.php
@@ -6,7 +6,7 @@
  * @author  Rodney Rehm
  */
 
-require_once(dirname(__FILE__) . '/helpers/_object_tostring.php');
+require_once(__DIR__ . '/helpers/_object_tostring.php');
 
 /**
  * class for modifier tests
@@ -19,7 +19,7 @@ class PluginFunctionHtmlCheckboxesTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testAssociativeArray()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlOptionsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlOptionsTest.php
@@ -6,7 +6,7 @@
  * @author  Rodney Rehm
  */
 
-require_once(dirname(__FILE__) . '/helpers/_object_tostring.php');
+require_once(__DIR__ . '/helpers/_object_tostring.php');
 
 /**
  * class for modifier tests
@@ -19,7 +19,7 @@ class PluginFunctionHtmlOptionsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testAssociativeArray()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlRadiosTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlRadiosTest.php
@@ -6,7 +6,7 @@
  * @author  Rodney Rehm
  */
 
-require_once(dirname(__FILE__) . '/helpers/_object_tostring.php');
+require_once(__DIR__ . '/helpers/_object_tostring.php');
 
 /**
  * class for modifier tests
@@ -18,7 +18,7 @@ class PluginFunctionHtmlRadiosTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testAssociativeArray()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlSelectDateTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlSelectDateTest.php
@@ -209,7 +209,7 @@ class PluginFunctionHtmlSelectDateTest extends PHPUnit_Smarty
 
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setErrorReporting(E_ALL & ~E_DEPRECATED);
 
         $year = date('Y');

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlSelectTimeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlSelectTimeTest.php
@@ -17,7 +17,7 @@ class PluginFunctionHtmlSelectTimeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->now = mktime(16, 15, 11, 2, 20, 2011);
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionMailtoTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionMailtoTest.php
@@ -17,7 +17,7 @@ class PluginFunctionMailtoTest extends PHPUnit_Smarty
 {
      public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCapitalizeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCapitalizeTest.php
@@ -17,7 +17,7 @@ class PluginModifierCapitalizeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCharsetTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCharsetTest.php
@@ -17,7 +17,7 @@ class PluginModifierCharsetTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testToLatin1()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountCharactersTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountCharactersTest.php
@@ -17,7 +17,7 @@ class PluginModifierCountCharactersTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountSentencesTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountSentencesTest.php
@@ -17,7 +17,7 @@ class PluginModifierCountSentencesTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountTest.php
@@ -14,7 +14,7 @@ class PluginModifierCountTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testArray()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountWordsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountWordsTest.php
@@ -17,7 +17,7 @@ class PluginModifierCountWordsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierDefaultTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierDefaultTest.php
@@ -17,7 +17,7 @@ class PluginModifierDefaultTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierEscapeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierEscapeTest.php
@@ -17,7 +17,7 @@ class PluginModifierEscapeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testHtml()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierLowerTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierLowerTest.php
@@ -16,7 +16,7 @@ class PluginModifierLowerTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierNl2brTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierNl2brTest.php
@@ -14,7 +14,7 @@ class PluginModifierNl2brTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierRegexReplaceTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierRegexReplaceTest.php
@@ -17,7 +17,7 @@ class PluginModifierRegexReplaceTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierSpacifyTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierSpacifyTest.php
@@ -17,7 +17,7 @@ class PluginModifierSpacifyTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierStrRepeatTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierStrRepeatTest.php
@@ -14,7 +14,7 @@ class PluginModifierStrRepeatTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierStripTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierStripTest.php
@@ -17,7 +17,7 @@ class PluginModifierStripTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierTruncateTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierTruncateTest.php
@@ -17,7 +17,7 @@ class PluginModifierTruncateTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierUnescapeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierUnescapeTest.php
@@ -17,7 +17,7 @@ class PluginModifierUnescapeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testHtml()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierUpperTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierUpperTest.php
@@ -17,7 +17,7 @@ class PluginModifierUpperTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierWordwrapTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierWordwrapTest.php
@@ -17,7 +17,7 @@ class PluginModifierWordwrapTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testDefault()

--- a/tests/UnitTests/TemplateSource/TagTests/Section/CompileSectionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Section/CompileSectionTest.php
@@ -17,7 +17,7 @@ class CompileSectionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/SetFilter/CompileSetfilterTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/SetFilter/CompileSetfilterTest.php
@@ -17,7 +17,7 @@ class CompileSetfilterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/Strip/CompileStripTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Strip/CompileStripTest.php
@@ -17,7 +17,7 @@ class CompileStripTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("./templates_tmp");
     }

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -17,7 +17,7 @@ class CompileFunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
    }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/While/CompileWhileTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/While/CompileWhileTest.php
@@ -17,7 +17,7 @@ class CompileWhileTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/_Attributes/AttributeTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/_Attributes/AttributeTest.php
@@ -17,7 +17,7 @@ class AttributeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/_Error/CompileErrorTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/_Error/CompileErrorTest.php
@@ -17,7 +17,7 @@ class CompileErrorTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/TagTests/_Print/PrintTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/_Print/PrintTest.php
@@ -17,7 +17,7 @@ class PrintTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/TagTests/break/CompileBreakTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/break/CompileBreakTest.php
@@ -17,7 +17,7 @@ class CompileBreakTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/ValueTests/Array/ArrayTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Array/ArrayTest.php
@@ -17,7 +17,7 @@ class ArrayTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/BoolenNull/BooleanNullTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/BoolenNull/BooleanNullTest.php
@@ -17,7 +17,7 @@ class BooleanNullTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/ConstantTests/ConstantsTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/ConstantTests/ConstantsTest.php
@@ -21,7 +21,7 @@ class ConstantsTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
 

--- a/tests/UnitTests/TemplateSource/ValueTests/DoubleQuoted/DoubleQuotedStringTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/DoubleQuoted/DoubleQuotedStringTest.php
@@ -17,7 +17,7 @@ class DoubleQuotedStringTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/ValueTests/Math/MathTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Math/MathTest.php
@@ -17,7 +17,7 @@ class MathTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->registerPlugin('modifier', 'sin', 'sin');
     }
 

--- a/tests/UnitTests/TemplateSource/ValueTests/Modifier/ModifierTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Modifier/ModifierTest.php
@@ -17,7 +17,7 @@ class ModifierTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addTemplateDir("./templates_tmp");
     }
 

--- a/tests/UnitTests/TemplateSource/ValueTests/Objects/ObjectVariableTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Objects/ObjectVariableTest.php
@@ -17,7 +17,7 @@ class ObjectVariableTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->setForceCompile(true);
     }
 

--- a/tests/UnitTests/TemplateSource/ValueTests/PHPfunctions/PhpFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/PHPfunctions/PhpFunctionTest.php
@@ -19,7 +19,7 @@ class PhpFunctionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SingleQouted/SingleQuotedStringTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SingleQouted/SingleQuotedStringTest.php
@@ -17,7 +17,7 @@ class SingleQuotedStringTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Constant/SmartyConstantTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Constant/SmartyConstantTest.php
@@ -17,7 +17,7 @@ class SmartyConstantTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Cookie/CookieTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Cookie/CookieTest.php
@@ -17,7 +17,7 @@ class CookieTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Delimiter/SmartyDelimiterTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Delimiter/SmartyDelimiterTest.php
@@ -17,7 +17,7 @@ class SmartyDelimiterTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Error/SmartyErrorTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Error/SmartyErrorTest.php
@@ -17,7 +17,7 @@ class SmartyErrorTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Now/SmartyNowTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Now/SmartyNowTest.php
@@ -17,7 +17,7 @@ class SmartyNowTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Post/PostTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Post/PostTest.php
@@ -17,7 +17,7 @@ class PostTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/TemplateObject/SmartyTemplateObjectTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/TemplateObject/SmartyTemplateObjectTest.php
@@ -17,7 +17,7 @@ class SmartyTemplateObjectTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Version/SmartyVersionTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Version/SmartyVersionTest.php
@@ -17,7 +17,7 @@ class SmartyVersionTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
@@ -17,7 +17,7 @@ class StreamVariableTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
 
         stream_wrapper_register("var", "VariableStream")
         or die("Failed to register protocol");

--- a/tests/UnitTests/TemplateSource/ValueTests/Variables/VariableVariable/VariableVariableTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Variables/VariableVariable/VariableVariableTest.php
@@ -17,7 +17,7 @@ class VariableVariableTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/X_Scopes/ScopeTest.php
+++ b/tests/UnitTests/TemplateSource/X_Scopes/ScopeTest.php
@@ -17,7 +17,7 @@ class ScopeTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->addPluginsDir("../../__shared/PHPunitplugins/");
         $this->smarty->addTemplateDir("../../__shared/templates/");
         $this->smarty->addTemplateDir("./templates_tmp");

--- a/tests/UnitTests/TemplateSource/Xml/XmlTest.php
+++ b/tests/UnitTests/TemplateSource/Xml/XmlTest.php
@@ -17,7 +17,7 @@ class XmlTest extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->enableSecurity();
         $this->smarty->setForceCompile(true);
     }

--- a/tests/UnitTests/TemplateSource/_Issues/327/ModifierIssue327Test.php
+++ b/tests/UnitTests/TemplateSource/_Issues/327/ModifierIssue327Test.php
@@ -17,7 +17,7 @@ class ModifierIssue327Test extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
         $this->smarty->registerPlugin('modifier', 'substr', 'substr');
     }
 

--- a/tests/UnitTests/TemplateSource/_Issues/419/ExtendsIssue419Test.php
+++ b/tests/UnitTests/TemplateSource/_Issues/419/ExtendsIssue419Test.php
@@ -17,7 +17,7 @@ class ExtendsIssue419Test extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/_Issues/422/NestedLoopIssue422Test.php
+++ b/tests/UnitTests/TemplateSource/_Issues/422/NestedLoopIssue422Test.php
@@ -19,7 +19,7 @@ class NestedLoopIssue422Test extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/_Issues/428/SectionPropertiesShortSyntaxIssue428Test.php
+++ b/tests/UnitTests/TemplateSource/_Issues/428/SectionPropertiesShortSyntaxIssue428Test.php
@@ -19,7 +19,7 @@ class SectionPropertiesShortSyntaxIssue428Test extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/tests/UnitTests/TemplateSource/_Issues/549/MbSplitEncodingIssue549Test.php
+++ b/tests/UnitTests/TemplateSource/_Issues/549/MbSplitEncodingIssue549Test.php
@@ -36,7 +36,7 @@ class MbSplitEncodingIssue549Test extends PHPUnit_Smarty
         }
 
         $this->charset = \Smarty::$_CHARSET;
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     protected function tearDown(): void

--- a/tests/UnitTests/TemplateSource/_Issues/topic26878/NewlineSpacing.php
+++ b/tests/UnitTests/TemplateSource/_Issues/topic26878/NewlineSpacing.php
@@ -17,7 +17,7 @@ class NewlineSpacing extends PHPUnit_Smarty
 {
     public function setUp(): void
     {
-        $this->setUpSmarty(dirname(__FILE__));
+        $this->setUpSmarty(__DIR__);
     }
 
     public function testInit()

--- a/utilities/BuildExpectedFiles.php
+++ b/utilities/BuildExpectedFiles.php
@@ -6,7 +6,7 @@
  * Time: 23:58
  */
 $sysplugins = array();
-$iterator = new DirectoryIterator(dirname(__FILE__) . '/../libs/sysplugins');
+$iterator = new DirectoryIterator(__DIR__ . '/../libs/sysplugins');
 foreach ($iterator as $file) {
     if (!$file->isDot() && 'php' == $file->getExtension()) {
         $filename = $file->getBasename();
@@ -14,16 +14,16 @@ foreach ($iterator as $file) {
     }
 }
 $plugins = array();
-$iterator = new DirectoryIterator(dirname(__FILE__) . '/../libs/plugins');
+$iterator = new DirectoryIterator(__DIR__ . '/../libs/plugins');
 foreach ($iterator as $file) {
     if (!$file->isDot() && 'php' == $file->getExtension()) {
         $filename = $file->getBasename();
         $plugins[ $filename ] = true;
     }
 }
-$code = file_get_contents(dirname(__FILE__) . '/../libs/sysplugins/smarty_internal_testinstall.php');
+$code = file_get_contents(__DIR__ . '/../libs/sysplugins/smarty_internal_testinstall.php');
 $expectedPlugins = '$expectedPlugins = ' . var_export($plugins, true);
 $code = preg_replace('#\$expectedPlugins =[^;]+#', $expectedPlugins, $code);
 $expectedSysplugins = '$expectedSysplugins = ' . var_export($sysplugins, true);
 $code = preg_replace('#\$expectedSysplugins =[^;]+#', $expectedSysplugins, $code);
-file_put_contents(dirname(__FILE__) . '/../libs/sysplugins/smarty_internal_testinstall.php', $code);
+file_put_contents(__DIR__ . '/../libs/sysplugins/smarty_internal_testinstall.php', $code);


### PR DESCRIPTION
This pull request brings fewer parentheses ;)

Smarty at the current moment needs at least PHP 7.1, so we can use `__DIR__` instead of `dirname(__FILE__)`. This makes the code a bit easier to read - fewer parentheses and also adds a micro-optimization for resolving directories - no function calls are needed because all paths resolving happens at compiling time.

It's not much but I hope this could be useful. 