### PR TITLE
Also mute php7 notices for undefined array indexes when muteUndefined…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `$smarty->muteUndefinedOrNullWarnings()` now also mutes PHP7 notices for undefined array indexes [#736](https://github.com/smarty-php/smarty/issues/736)
+
 ## [4.3.0] - 2022-11-22
 
 ### Added

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -1386,8 +1386,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     }
 
     /**
-     * Activates PHP7 compatibility mode:
-     * - converts E_WARNINGS for "undefined array key" and "trying to read property of null" errors to E_NOTICE
+     * Mutes errors for "undefined index", "undefined array key" and "trying to read property of null".
      *
      * @void
      */
@@ -1396,7 +1395,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     }
 
     /**
-     * Indicates if PHP7 compatibility mode is set.
+     * Indicates if Smarty will mute errors for "undefined index", "undefined array key" and "trying to read property of null".
      * @bool
      */
     public function isMutingUndefinedOrNullWarnings(): bool {

--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -71,7 +71,7 @@ class Smarty_Internal_ErrorHandler
         }
 
         if ($this->allowUndefinedArrayKeys && preg_match(
-            '/^(Undefined array key|Trying to access array offset on value of type null)/',
+            '/^(Undefined index|Undefined array key|Trying to access array offset on value of type null)/',
             $errstr
         )) {
             return; // suppresses this error


### PR DESCRIPTION
…OrNullWarnings is activated.

Fixes #736