### PR TITLE
Allow dereferencing of non-objects accross all supported PHP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `$smarty->muteUndefinedOrNullWarnings()` now also mutes PHP7 notices for undefined array indexes [#736](https://github.com/smarty-php/smarty/issues/736)
 - `$smarty->muteUndefinedOrNullWarnings()` now treats undefined vars and array access of a null or false variables 
   equivalent across all supported PHP versions
-
+- `$smarty->muteUndefinedOrNullWarnings()` now allows dereferencing of non-objects accross all supported PHP versions [#831](https://github.com/smarty-php/smarty/issues/831)
 ## [4.3.0] - 2022-11-22
 
 ### Added

--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -23,6 +23,12 @@ class Smarty_Internal_ErrorHandler
      */
     public $allowUndefinedArrayKeys = true;
 
+    /**
+     * Allows {$foo->bar} where bar is not an object (e.g. null or false).
+     * @var bool
+     */
+    public $allowDereferencingNonObjects = true;
+
     private $previousErrorHandler = null;
 
     /**
@@ -75,9 +81,16 @@ class Smarty_Internal_ErrorHandler
         }
 
         if ($this->allowUndefinedArrayKeys && preg_match(
-            '/^(Undefined index|Undefined array key|Trying to access array offset on value of type (null|bool))/',
+            '/^(Undefined index|Undefined array key|Trying to access array offset on value of type)/',
             $errstr
         )) {
+            return; // suppresses this error
+        }
+
+        if ($this->allowDereferencingNonObjects && preg_match(
+                '/^Attempt to read property ".+?" on/',
+                $errstr
+            )) {
             return; // suppresses this error
         }
 

--- a/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
+++ b/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
@@ -145,4 +145,37 @@ class UndefinedTemplateVarTest extends PHPUnit_Smarty
         $this->assertEquals("ab", $this->smarty->fetch($tpl));
     }
 
+	/**
+	 * @group 20221124
+	 */
+	public function testDereferenceOnNull() {
+		$this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
+		$this->smarty->muteUndefinedOrNullWarnings();
+		$tpl = $this->smarty->createTemplate('string:a{if $object->myprop}def{/if}b');
+		$this->smarty->assign('object', null);
+		$this->assertEquals("ab", $this->smarty->fetch($tpl));
+	}
+
+	/**
+	 * @group 20221124
+	 */
+	public function testDereferenceOnBool() {
+		$this->smarty->setErrorReporting(E_ALL & ~E_NOTICE);
+		$this->smarty->muteUndefinedOrNullWarnings();
+		$tpl = $this->smarty->createTemplate('string:a{if $object->myprop}def{/if}b');
+		$this->smarty->assign('object', false);
+		$this->assertEquals("ab", $this->smarty->fetch($tpl));
+	}
+
+	/**
+	 * @group 20221124
+	 */
+	public function testDereferenceOnString() {
+		$this->smarty->setErrorReporting(E_ALL & ~E_NOTICE);
+		$this->smarty->muteUndefinedOrNullWarnings();
+		$tpl = $this->smarty->createTemplate('string:a{if $object->myprop}def{/if}b');
+		$this->smarty->assign('object', 'xyz');
+		$this->assertEquals("ab", $this->smarty->fetch($tpl));
+	}
+
 }


### PR DESCRIPTION
Fixes #831