### PR TITLE
Fix PHP8.1 deprecation warnings on null string in modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `$smarty->muteUndefinedOrNullWarnings()` now also mutes PHP7 notices for undefined array indexes [#736](https://github.com/smarty-php/smarty/issues/736)
 - `$smarty->muteUndefinedOrNullWarnings()` now treats undefined vars and array access of a null or false variables 
   equivalent across all supported PHP versions
-- `$smarty->muteUndefinedOrNullWarnings()` now allows dereferencing of non-objects accross all supported PHP versions [#831](https://github.com/smarty-php/smarty/issues/831)
+- `$smarty->muteUndefinedOrNullWarnings()` now allows dereferencing of non-objects across all supported PHP versions [#831](https://github.com/smarty-php/smarty/issues/831)
+- PHP 8.1 deprecation warnings on null strings in modifiers [#834](https://github.com/smarty-php/smarty/pull/834)
+
 ## [4.3.0] - 2022-11-22
 
 ### Added
@@ -31,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed PHP8.1 deprecation errors passing null to parameter in trim [#807](https://github.com/smarty-php/smarty/pull/807)
 - Adapt Smarty upper/lower functions to be codesafe (e.g. for Turkish locale) [#586](https://github.com/smarty-php/smarty/pull/586)
 - Bug fix for underscore and limited length in template name in custom resources [#581](https://github.com/smarty-php/smarty/pull/581)
-
 
 ## [4.2.1] - 2022-09-14
 

--- a/libs/plugins/modifier.truncate.php
+++ b/libs/plugins/modifier.truncate.php
@@ -26,7 +26,7 @@
  */
 function smarty_modifier_truncate($string, $length = 80, $etc = '...', $break_words = false, $middle = false)
 {
-    if ($length === 0) {
+    if ($length === 0 || $string === null) {
         return '';
     }
     if (Smarty::$_MBSTRING) {

--- a/libs/plugins/modifiercompiler.count_characters.php
+++ b/libs/plugins/modifiercompiler.count_characters.php
@@ -25,8 +25,8 @@ function smarty_modifiercompiler_count_characters($params)
         return 'preg_match_all(\'/[^\s]/' . Smarty::$_UTF8_MODIFIER . '\',' . $params[ 0 ] . ', $tmp)';
     }
     if (Smarty::$_MBSTRING) {
-        return 'mb_strlen(' . $params[ 0 ] . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
+        return 'mb_strlen((string) ' . $params[ 0 ] . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
     }
     // no MBString fallback
-    return 'strlen(' . $params[ 0 ] . ')';
+    return 'strlen((string) ' . $params[ 0 ] . ')';
 }

--- a/libs/plugins/modifiercompiler.count_words.php
+++ b/libs/plugins/modifiercompiler.count_words.php
@@ -27,5 +27,5 @@ function smarty_modifiercompiler_count_words($params)
                $params[ 0 ] . ', $tmp)';
     }
     // no MBString fallback
-    return 'str_word_count(' . $params[ 0 ] . ')';
+    return 'str_word_count((string) ' . $params[ 0 ] . ')';
 }

--- a/libs/plugins/modifiercompiler.lower.php
+++ b/libs/plugins/modifiercompiler.lower.php
@@ -22,8 +22,8 @@
 function smarty_modifiercompiler_lower($params)
 {
     if (Smarty::$_MBSTRING) {
-        return 'mb_strtolower(' . $params[ 0 ] . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
+        return 'mb_strtolower((string) ' . $params[ 0 ] . ', \'' . addslashes(Smarty::$_CHARSET) . '\')';
     }
     // no MBString fallback
-    return 'strtolower(' . $params[ 0 ] . ')';
+    return 'strtolower((string) ' . $params[ 0 ] . ')';
 }

--- a/libs/plugins/modifiercompiler.upper.php
+++ b/libs/plugins/modifiercompiler.upper.php
@@ -21,8 +21,8 @@
 function smarty_modifiercompiler_upper($params)
 {
     if (Smarty::$_MBSTRING) {
-        return 'mb_strtoupper(' . $params[ 0 ] . ' ?? \'\', \'' . addslashes(Smarty::$_CHARSET) . '\')';
+        return 'mb_strtoupper((string) ' . $params[ 0 ] . ' ?? \'\', \'' . addslashes(Smarty::$_CHARSET) . '\')';
     }
     // no MBString fallback
-    return 'strtoupper(' . $params[ 0 ] . ' ?? \'\')';
+    return 'strtoupper((string) ' . $params[ 0 ] . ' ?? \'\')';
 }

--- a/libs/plugins/outputfilter.trimwhitespace.php
+++ b/libs/plugins/outputfilter.trimwhitespace.php
@@ -62,7 +62,7 @@ function smarty_outputfilter_trimwhitespace($source)
         }
     }
     $expressions = array(// replace multiple spaces between tags by a single space
-                         // can't remove them entirely, becaue that might break poorly implemented CSS display:inline-block elements
+                         // can't remove them entirely, because that might break poorly implemented CSS display:inline-block elements
                          '#(:SMARTY@!@|>)\s+(?=@!@SMARTY:|<)#s'                                    => '\1 \2',
                          // remove spaces between attributes (but not in attribute values!)
                          '#(([a-z0-9]\s*=\s*("[^"]*?")|(\'[^\']*?\'))|<[a-z0-9_]+)\s+([a-z/>])#is' => '\1 \5',

--- a/libs/plugins/shared.escape_special_chars.php
+++ b/libs/plugins/shared.escape_special_chars.php
@@ -20,7 +20,7 @@
 function smarty_function_escape_special_chars($string)
 {
     if (!is_array($string)) {
-        $string = htmlspecialchars($string, ENT_COMPAT, Smarty::$_CHARSET, false);
+        $string = htmlspecialchars((string) $string, ENT_COMPAT, Smarty::$_CHARSET, false);
     }
     return $string;
 }

--- a/libs/plugins/variablefilter.htmlspecialchars.php
+++ b/libs/plugins/variablefilter.htmlspecialchars.php
@@ -15,5 +15,5 @@
  */
 function smarty_variablefilter_htmlspecialchars($source, Smarty_Internal_Template $template)
 {
-    return htmlspecialchars($source, ENT_QUOTES, Smarty::$_CHARSET);
+    return htmlspecialchars((string) $source, ENT_QUOTES, Smarty::$_CHARSET);
 }


### PR DESCRIPTION
I noticed that if one is calling `|truncate` on null, it triggers `E_DEPRECATED: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated` on PHP 8.1.

This is expected, but given the modifier accepts null we may as well return an empty string before calling the function.