### PR TITLE
New use_only_compiled option

### DIFF
--- a/docs/programmers/api-variables.md
+++ b/docs/programmers/api-variables.md
@@ -45,6 +45,7 @@ them directly, or use the corresponding setter/getter methods.
 - [$template_dir](./api-variables/variable-template-dir.md)
 - [$trusted_dir](./api-variables/variable-trusted-dir.md)
 - [$use_include_path](./api-variables/variable-use-include-path.md)
+- [$use_only_compiled](./api-variables/variable-use-only-compiled.md)
 - [$use_sub_dirs](./api-variables/variable-use-sub-dirs.md)
 
 > **Note**

--- a/docs/programmers/api-variables/variable-use-only-compiled.md
+++ b/docs/programmers/api-variables/variable-use-only-compiled.md
@@ -1,0 +1,9 @@
+\$use\_only\_compiled {#variable.use.only.compiled}
+================
+
+If set to TRUE, Smarty will use only compiled templates, alsoù
+ignoring the (in)existence of base templates. Compiled filenames
+will be constant and relative to the template basename.
+Useful to use pre-compiled templates and distribute them already
+compiled on production websites. Overrides and disables
+[`$merge_compiled_includes`](#variable.merge.compiled.includes)

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -579,6 +579,13 @@ class Smarty extends Smarty_Internal_TemplateBase
     public $_debug = null;
 
     /**
+     * force using of only compiled templates, ignoring source
+     *
+     * @var boolean
+     */
+    public $use_only_compiled = false;
+
+    /**
      * template directory
      *
      * @var array
@@ -1277,6 +1284,14 @@ class Smarty extends Smarty_Internal_TemplateBase
     public function setCachingType($caching_type)
     {
         $this->caching_type = $caching_type;
+    }
+
+    /**
+     * @param boolean $use_only_compiled
+     */
+    public function setUseOnlyCompiled($use_only_compiled)
+    {
+        $this->use_only_compiled = $use_only_compiled;
     }
 
     /**

--- a/libs/sysplugins/smarty_internal_compile_include.php
+++ b/libs/sysplugins/smarty_internal_compile_include.php
@@ -145,6 +145,10 @@ class Smarty_Internal_Compile_Include extends Smarty_Internal_CompileBase
             if (isset($_attr[ 'compile_id' ]) && $compiler->isVariable($_attr[ 'compile_id' ])) {
                 $merge_compiled_includes = false;
             }
+            // compile names without uid
+            if ($compiler->smarty->use_only_compiled) {
+                $merge_compiled_includes = false;
+            }
         }
         /*
         * if the {include} tag provides individual parameter for caching or compile_id

--- a/libs/sysplugins/smarty_internal_template.php
+++ b/libs/sysplugins/smarty_internal_template.php
@@ -192,7 +192,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
             $this->smarty->_debug->start_template($this, $display);
         }
         // checks if template exists
-        if (!$this->source->exists) {
+        if (!$this->source->exists && !$this->smarty->use_only_compiled) {
             throw new SmartyException(
                 "Unable to load template '{$this->source->type}:{$this->source->name}'" .
                 ($this->_isSubTpl() ? " in '{$this->parent->template_resource}'" : '')


### PR DESCRIPTION
If set to TRUE, Smarty will use only compiled templates, also
ignoring the (in)existence of base templates. Compiled filenames
will be constant and relative to the template basename.
Useful to use pre-compiled templates and distribute them already
compiled on production websites. Overrides and disables
$merge_compiled_includes