### PR TITLE
Fix PHP 8.1 deprecation notice in `truncate` for NULL values

### DIFF
--- a/libs/plugins/modifier.truncate.php
+++ b/libs/plugins/modifier.truncate.php
@@ -26,7 +26,7 @@
  */
 function smarty_modifier_truncate($string, $length = 80, $etc = '...', $break_words = false, $middle = false)
 {
-    if ($length === 0) {
+    if ($length === 0 || $string === null) {
         return '';
     }
     if (Smarty::$_MBSTRING) {


### PR DESCRIPTION
If the input string is a `NULL` value, PHP 8.1 throws the following deprecation notice:
```
mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```
Catching it in the modifier avoids having to add boilerplate `NULL` checks in the template.