### PR TITLE
Bubbling up of parent scope in template blocks with inheritance chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Updating variable in parent scope (when the `scope=parent` is explicitly used on a tag like `assign`) now bubbles up (to the including template) even when the included template is part of an inheritance chain as it did pre `v3.1.28`.
 - `$smarty->muteUndefinedOrNullWarnings()` now also mutes PHP7 notices for undefined array indexes [#736](https://github.com/smarty-php/smarty/issues/736)
 - `$smarty->muteUndefinedOrNullWarnings()` now treats undefined vars and array access of a null or false variables 
   equivalent across all supported PHP versions

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -1050,7 +1050,7 @@ class Smarty extends Smarty_Internal_TemplateBase
         $cache_id = null,
         $compile_id = null,
         $caching = null,
-        Smarty_Internal_Template $template = null
+        ?Smarty_Internal_Template $template = null
     ) {
         $template_name = (strpos($template_name, ':') === false) ? "{$this->default_resource_type}:{$template_name}" :
             $template_name;

--- a/libs/sysplugins/smarty_cacheresource.php
+++ b/libs/sysplugins/smarty_cacheresource.php
@@ -52,7 +52,7 @@ abstract class Smarty_CacheResource
      */
     abstract public function process(
         Smarty_Internal_Template $_template,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     );
 

--- a/libs/sysplugins/smarty_cacheresource_custom.php
+++ b/libs/sysplugins/smarty_cacheresource_custom.php
@@ -132,7 +132,7 @@ abstract class Smarty_CacheResource_Custom extends Smarty_CacheResource
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         if (!$cached) {

--- a/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
+++ b/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
@@ -96,7 +96,7 @@ abstract class Smarty_CacheResource_KeyValueStore extends Smarty_CacheResource
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         if (!$cached) {

--- a/libs/sysplugins/smarty_internal_cacheresource_file.php
+++ b/libs/sysplugins/smarty_internal_cacheresource_file.php
@@ -96,7 +96,7 @@ class Smarty_Internal_CacheResource_File extends Smarty_CacheResource
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         $_smarty_tpl->cached->valid = false;

--- a/libs/sysplugins/smarty_internal_data.php
+++ b/libs/sysplugins/smarty_internal_data.php
@@ -190,7 +190,7 @@ abstract class Smarty_Internal_Data
      *
      * @return mixed variable value or or array of variables
      */
-    public function getTemplateVars($varName = null, Smarty_Internal_Data $_ptr = null, $searchParents = true)
+    public function getTemplateVars($varName = null, ?Smarty_Internal_Data $_ptr = null, $searchParents = true)
     {
         return $this->ext->getTemplateVars->getTemplateVars($this, $varName, $_ptr, $searchParents);
     }
@@ -200,7 +200,7 @@ abstract class Smarty_Internal_Data
      *
      * @param \Smarty_Internal_Data|null $data
      */
-    public function _mergeVars(Smarty_Internal_Data $data = null)
+    public function _mergeVars(?Smarty_Internal_Data $data = null)
     {
         if (isset($data)) {
             if (!empty($this->tpl_vars)) {

--- a/libs/sysplugins/smarty_internal_method_configload.php
+++ b/libs/sysplugins/smarty_internal_method_configload.php
@@ -89,11 +89,10 @@ class Smarty_Internal_Method_ConfigLoad
                 }
             }
             if ($tpl->parent->_isTplObj() && ($tagScope || $tpl->parent->scope)) {
-                $mergedScope = $tagScope | $tpl->scope;
-                if ($mergedScope) {
+                if ($tagScope | $tpl->scope) {
                     // update scopes
                     /* @var \Smarty_Internal_Template|\Smarty|\Smarty_Internal_Data $ptr */
-                    foreach ($tpl->smarty->ext->_updateScope->_getAffectedScopes($tpl->parent, $mergedScope) as $ptr) {
+                    foreach ($tpl->smarty->ext->_updateScope->_getAffectedScopes($tpl->parent, $tagScope) as $ptr) {
                         $this->_assignConfigVars($ptr->config_vars, $tpl, $new_config_vars);
                         if ($tagScope && $ptr->_isTplObj() && isset($tpl->_cache[ 'varStack' ])) {
                             $this->_updateVarStack($tpl, $new_config_vars);

--- a/libs/sysplugins/smarty_internal_method_createdata.php
+++ b/libs/sysplugins/smarty_internal_method_createdata.php
@@ -31,7 +31,7 @@ class Smarty_Internal_Method_CreateData
      *
      * @return \Smarty_Data data object
      */
-    public function createData(Smarty_Internal_TemplateBase $obj, Smarty_Internal_Data $parent = null, $name = null)
+    public function createData(Smarty_Internal_TemplateBase $obj, ?Smarty_Internal_Data $parent = null, $name = null)
     {
         /* @var Smarty $smarty */
         $smarty = $obj->_getSmartyObj();

--- a/libs/sysplugins/smarty_internal_method_gettemplatevars.php
+++ b/libs/sysplugins/smarty_internal_method_gettemplatevars.php
@@ -34,7 +34,7 @@ class Smarty_Internal_Method_GetTemplateVars
     public function getTemplateVars(
         Smarty_Internal_Data $data,
         $varName = null,
-        Smarty_Internal_Data $_ptr = null,
+        ?Smarty_Internal_Data $_ptr = null,
         $searchParents = true
     ) {
         if (isset($varName)) {
@@ -87,7 +87,7 @@ class Smarty_Internal_Method_GetTemplateVars
     public function _getVariable(
         Smarty_Internal_Data $data,
         $varName,
-        Smarty_Internal_Data $_ptr = null,
+        ?Smarty_Internal_Data $_ptr = null,
         $searchParents = true,
         $errorEnable = true
     ) {

--- a/libs/sysplugins/smarty_internal_resource_eval.php
+++ b/libs/sysplugins/smarty_internal_resource_eval.php
@@ -26,7 +26,7 @@ class Smarty_Internal_Resource_Eval extends Smarty_Resource_Recompiled
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->uid = $source->filepath = sha1($source->name);
         $source->timestamp = $source->exists = true;

--- a/libs/sysplugins/smarty_internal_resource_extends.php
+++ b/libs/sysplugins/smarty_internal_resource_extends.php
@@ -32,7 +32,7 @@ class Smarty_Internal_Resource_Extends extends Smarty_Resource
      *
      * @throws SmartyException
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $uid = '';
         $sources = array();

--- a/libs/sysplugins/smarty_internal_resource_file.php
+++ b/libs/sysplugins/smarty_internal_resource_file.php
@@ -25,7 +25,7 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      *
      * @throws \SmartyException
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = $this->buildFilepath($source, $_template);
         if ($source->filepath !== false) {
@@ -98,7 +98,7 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      * @return string fully qualified filepath
      * @throws SmartyException
      */
-    protected function buildFilepath(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    protected function buildFilepath(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $file = $source->name;
         // absolute file ?

--- a/libs/sysplugins/smarty_internal_resource_stream.php
+++ b/libs/sysplugins/smarty_internal_resource_stream.php
@@ -27,7 +27,7 @@ class Smarty_Internal_Resource_Stream extends Smarty_Resource_Recompiled
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         if (strpos($source->resource, '://') !== false) {
             $source->filepath = $source->resource;

--- a/libs/sysplugins/smarty_internal_resource_string.php
+++ b/libs/sysplugins/smarty_internal_resource_string.php
@@ -26,7 +26,7 @@ class Smarty_Internal_Resource_String extends Smarty_Resource
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->uid = $source->filepath = sha1($source->name . $source->smarty->_joined_template_dir);
         $source->timestamp = $source->exists = true;

--- a/libs/sysplugins/smarty_internal_runtime_codeframe.php
+++ b/libs/sysplugins/smarty_internal_runtime_codeframe.php
@@ -30,7 +30,7 @@ class Smarty_Internal_Runtime_CodeFrame
         $content = '',
         $functions = '',
         $cache = false,
-        Smarty_Internal_TemplateCompilerBase $compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $compiler = null
     ) {
         // build property code
         $properties[ 'version' ] = Smarty::SMARTY_VERSION;

--- a/libs/sysplugins/smarty_internal_runtime_inheritance.php
+++ b/libs/sysplugins/smarty_internal_runtime_inheritance.php
@@ -168,7 +168,7 @@ class Smarty_Internal_Runtime_Inheritance
     public function process(
         Smarty_Internal_Template $tpl,
         Smarty_Internal_Block $block,
-        Smarty_Internal_Block $parent = null
+        ?Smarty_Internal_Block $parent = null
     ) {
         if ($block->hide && !isset($block->child)) {
             return;

--- a/libs/sysplugins/smarty_internal_template.php
+++ b/libs/sysplugins/smarty_internal_template.php
@@ -149,7 +149,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
     public function __construct(
         $template_resource,
         Smarty $smarty,
-        Smarty_Internal_Data $_parent = null,
+        ?Smarty_Internal_Data $_parent = null,
         $_cache_id = null,
         $_compile_id = null,
         $_caching = null,

--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -386,7 +386,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
     public function compileTemplate(
         Smarty_Internal_Template $template,
         $nocache = null,
-        Smarty_Internal_TemplateCompilerBase $parent_compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $parent_compiler = null
     ) {
         // get code frame of compiled template
         $_compiled_code = $template->smarty->ext->_codeFrame->create(
@@ -417,7 +417,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
     public function compileTemplateSource(
         Smarty_Internal_Template $template,
         $nocache = null,
-        Smarty_Internal_TemplateCompilerBase $parent_compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $parent_compiler = null
     ) {
         try {
             // save template object in compiler class

--- a/libs/sysplugins/smarty_resource.php
+++ b/libs/sysplugins/smarty_resource.php
@@ -173,8 +173,8 @@ abstract class Smarty_Resource
      * @throws \SmartyException
      */
     public static function source(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         return Smarty_Template_Source::load($_template, $smarty, $template_resource);
@@ -196,7 +196,7 @@ abstract class Smarty_Resource
      * @param Smarty_Template_Source   $source    source object
      * @param Smarty_Internal_Template $_template template object
      */
-    abstract public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null);
+    abstract public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null);
 
     /**
      * populate Source Object with timestamp and exists from Resource

--- a/libs/sysplugins/smarty_resource_custom.php
+++ b/libs/sysplugins/smarty_resource_custom.php
@@ -45,7 +45,7 @@ abstract class Smarty_Resource_Custom extends Smarty_Resource
      * @param Smarty_Template_Source   $source    source object
      * @param Smarty_Internal_Template $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = $source->type . ':' . $this->generateSafeName($source->name);
         $source->uid = sha1($source->type . ':' . $source->name);

--- a/libs/sysplugins/smarty_template_config.php
+++ b/libs/sysplugins/smarty_template_config.php
@@ -71,8 +71,8 @@ class Smarty_Template_Config extends Smarty_Template_Source
      * @throws SmartyException
      */
     public static function load(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         static $_incompatible_resources = array('extends' => true, 'php' => true);

--- a/libs/sysplugins/smarty_template_source.php
+++ b/libs/sysplugins/smarty_template_source.php
@@ -156,8 +156,8 @@ class Smarty_Template_Source
      * @throws SmartyException
      */
     public static function load(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         if ($_template) {

--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -21,7 +21,7 @@ class SmartyCompilerException extends SmartyException
         int $code = 0,
         ?string $filename = null,
         ?int $line = null,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
@@ -8,7 +8,7 @@ class Smarty_Resource_Filetest extends Smarty_Internal_Resource_File
      * @param Smarty_Template_Source   $source    source object
      * @param Smarty_Internal_Template $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         parent::populate($source, $_template);
         if ($source->exists) {

--- a/tests/UnitTests/ConfigFileTests/file/PHPunitplugins/resource.db4.php
+++ b/tests/UnitTests/ConfigFileTests/file/PHPunitplugins/resource.db4.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db4 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db4:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
+++ b/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
@@ -41,7 +41,7 @@ class Smarty_Resource_Ambiguous extends Smarty_Internal_Resource_File
      * @param Smarty_Template_Source   $source    source object
      * @param Smarty_Internal_Template $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $segment = '';
         if ($this->segment) {

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db extends Smarty_Resource_Recompiled {
 
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null) {
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null) {
         $source->filepath = 'db:';
         $source->uid = sha1($source->resource);
         $source->timestamp = 1000000000;

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db2 extends Smarty_Resource_Recompiled
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db2:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db3 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db3:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db4 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db4:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/TemplateSource/X_Scopes/ScopeTest.php
+++ b/tests/UnitTests/TemplateSource/X_Scopes/ScopeTest.php
@@ -238,7 +238,16 @@ class ScopeTest extends PHPUnit_Smarty
                            '', $i ++), array('{include \'test_scope_assign_noscope.tpl\' scope=root}', true,
                                              '#test_scope_assign_noscope.tpl:$foo =\'newvar\'#testIncludeScope_' . $i .
                                              '.tpl:$foo =\'data\'#test_scope.tpl:$foo =\'data\'#data:$foo =\'data\'#Smarty:$foo =\'smarty\'#global:$foo =\'global\'',
-                                             '', $i ++),);
+                                             '', $i ++),
+                     array('{include \'test_scope_inheritance_include.tpl\'}', true,
+                           '#test_scope_inheritance_include.tpl:$foo =\'data\'#testIncludeScope_'. $i .
+                           '.tpl:$foo =\'data\'#test_scope.tpl:$foo =\'data\'#data:$foo =\'data\'#Smarty:$foo =\'smarty\'#global:$foo =\'global\'',
+                           '', $i ++),
+                     array('{include \'test_scope_inheritance_include_assign_parent.tpl\'}', true,
+                           '#test_scope_inheritance_include_assign_parent.tpl:$foo =\'parent\'#testIncludeScope_'. $i .
+                           '.tpl:$foo =\'data\'#test_scope.tpl:$foo =\'data\'#data:$foo =\'data\'#Smarty:$foo =\'smarty\'#global:$foo =\'global\'',
+                           '', $i ++)
+        );
     }
 
     /**

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_child.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_child.tpl
@@ -1,0 +1,1 @@
+{extends './test_scope_inheritance_parent.tpl'}

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_child_assign_parent.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_child_assign_parent.tpl
@@ -1,0 +1,1 @@
+{extends './test_scope_inheritance_parent_assign_parent.tpl'}

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_include.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_include.tpl
@@ -1,0 +1,1 @@
+{include './test_scope_inheritance_child.tpl'}{checkvar var=foo}

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_include_assign_parent.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_include_assign_parent.tpl
@@ -1,0 +1,1 @@
+{include './test_scope_inheritance_child_assign_parent.tpl'}{checkvar var=foo}

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_parent.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_parent.tpl
@@ -1,0 +1,1 @@
+{$foo = 'parent'}

--- a/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_parent_assign_parent.tpl
+++ b/tests/UnitTests/TemplateSource/X_Scopes/templates/test_scope_inheritance_parent_assign_parent.tpl
@@ -1,0 +1,1 @@
+{$foo = 'parent' scope=parent}


### PR DESCRIPTION
Updating variable in parent scope (when the `scope=parent` is explicitly used on a tag like `assign`) now bubbles up (to the including template) even when the included template is part of an inheritance chain **as it did pre `v3.1.28`**.

Fixes https://github.com/smarty-php/smarty/issues/850

