### PR TITLE
Fixing the warning of unintialized variables in php 8.1

### DIFF
--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -574,7 +574,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
                                  )->nocache;
             // todo $this->template->compiled->properties['variables'][$var] = $this->tag_nocache | $this->nocache;
         }
-        return '$_smarty_tpl->tpl_vars[' . $variable . ']->value';
+        return '($_smarty_tpl->tpl_vars[' . $variable . ']->value ?? NULL)';
     }
 
     /**


### PR DESCRIPTION
While working on the PHP 8.1 refactoring I came across a common problem/error related to accessing variables in the tpl files that are not set/passed from the controller.
Instead of checking at all places if the variable is set or not, we can fix it by passing the defult NULL value.