### PR TITLE
Upgrade actions/checkout and actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Override PHP ini values for JIT compiler
       if: matrix.compiler == 'jit'
@@ -68,7 +68,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
This PR upgrades `actions/checkout` and `actions/cache` used in GitHub actions to reduce 40 warnings shown in the [action page](https://github.com/smarty-php/smarty/actions/runs/4257111806).