### PR TITLE
Remove `md5` modifier from debug.tpl

### DIFF
--- a/libs/debug.tpl
+++ b/libs/debug.tpl
@@ -167,9 +167,7 @@
     </html>
 {/capture}
 <script type="text/javascript">
-    {$id = '__Smarty__'}
-    {if $display_mode}{$id = md5("$offset$template_name")}{/if}
-    _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
+    _smarty_console = window.open("", "console{$targetWindow}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
     _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
     _smarty_console.document.close();
 </script>

--- a/libs/debug.tpl
+++ b/libs/debug.tpl
@@ -168,7 +168,7 @@
 {/capture}
 <script type="text/javascript">
     {$id = '__Smarty__'}
-    {if $display_mode}{$id = "$offset$template_name"|md5}{/if}
+    {if $display_mode}{$id = md5("$offset$template_name")}{/if}
     _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
     _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
     _smarty_console.document.close();

--- a/libs/sysplugins/smarty_internal_debug.php
+++ b/libs/sysplugins/smarty_internal_debug.php
@@ -238,9 +238,12 @@ class Smarty_Internal_Debug extends Smarty_Internal_Data
         $_config_vars = $ptr->config_vars;
         ksort($_config_vars);
         $debugging = $smarty->debugging;
+        $templateName = $obj->source->type . ':' . $obj->source->name;
+        $displayMode = $debugging === 2 || !$full;
+        $offset = $this->offset * 50;
         $_template = new Smarty_Internal_Template($debObj->debug_tpl, $debObj);
         if ($obj->_isTplObj()) {
-            $_template->assign('template_name', $obj->source->type . ':' . $obj->source->name);
+            $_template->assign('template_name', $templateName);
         }
         if ($obj->_objType === 1 || $full) {
             $_template->assign('template_data', $this->template_data[ $this->index ]);
@@ -250,8 +253,8 @@ class Smarty_Internal_Debug extends Smarty_Internal_Data
         $_template->assign('assigned_vars', $_assigned_vars);
         $_template->assign('config_vars', $_config_vars);
         $_template->assign('execution_time', microtime(true) - $smarty->start_time);
-        $_template->assign('display_mode', $debugging === 2 || !$full);
-        $_template->assign('offset', $this->offset * 50);
+        $_template->assign('targetWindow', $displayMode ? md5("$offset$templateName") : '__Smarty__');
+        $_template->assign('offset', $offset);
         echo $_template->fetch();
         if (isset($full)) {
             $this->index--;


### PR DESCRIPTION
Replaced with a regular function call. 
See https://github.com/smarty-php/smarty/issues/813