### PR TITLE
2.6 - Fix e-notice in modifier.escape.php

### DIFF
--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -21,6 +21,11 @@
  */
 function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-8859-1')
 {
+    // Early return for null, '', or '0', none of which need to be escaped and null will cause e-notices.
+    if (empty($string)) {
+        return (string) $string;
+    }
+
     switch ($esc_type) {
         case 'html':
             return htmlspecialchars($string, ENT_QUOTES, $char_set);


### PR DESCRIPTION
A `null` value will cause e-notices in most of the esc_types. Functions like `htmlspecialchars`, `str_replace`, `preg_replace` etc do not strictly allow `null` as an argument.
Using an early-return if the value is `empty()` should also give a subtle performance boost, as none of the esc_types do anything meaningful to empty strings or the number 0.