### PR TITLE
date_format: check if already exists

### DIFF
--- a/libs/plugins/modifier.date_format.php
+++ b/libs/plugins/modifier.date_format.php
@@ -5,82 +5,84 @@
  * @package    Smarty
  * @subpackage PluginsModifier
  */
-/**
- * Smarty date_format modifier plugin
- * Type:     modifier
- * Name:     date_format
- * Purpose:  format datestamps via strftime
- * Input:
- *          - string: input date string
- *          - format: strftime format for output
- *          - default_date: default date if $string is empty
- *
- * @link   https://www.smarty.net/manual/en/language.modifier.date.format.php date_format (Smarty online manual)
- * @author Monte Ohrt <monte at ohrt dot com>
- *
- * @param string $string       input date string
- * @param string $format       strftime format for output
- * @param string $default_date default date if $string is empty
- * @param string $formatter    either 'strftime' or 'auto'
- *
- * @return string |void
- * @uses   smarty_make_timestamp()
- */
-function smarty_modifier_date_format($string, $format = null, $default_date = '', $formatter = 'auto')
-{
-    if ($format === null) {
-        $format = Smarty::$_DATE_FORMAT;
-    }
+if (!function_exists('smarty_modifier_date_format')) {
     /**
-     * require_once the {@link shared.make_timestamp.php} plugin
+     * Smarty date_format modifier plugin
+     * Type:     modifier
+     * Name:     date_format
+     * Purpose:  format datestamps via strftime
+     * Input:
+     *          - string: input date string
+     *          - format: strftime format for output
+     *          - default_date: default date if $string is empty
+     *
+     * @link   https://www.smarty.net/manual/en/language.modifier.date.format.php date_format (Smarty online manual)
+     * @author Monte Ohrt <monte at ohrt dot com>
+     *
+     * @param string $string       input date string
+     * @param string $format       strftime format for output
+     * @param string $default_date default date if $string is empty
+     * @param string $formatter    either 'strftime' or 'auto'
+     *
+     * @return string |void
+     * @uses   smarty_make_timestamp()
      */
-    static $is_loaded = false;
-    if (!$is_loaded) {
-        if (!is_callable('smarty_make_timestamp')) {
-            include_once SMARTY_PLUGINS_DIR . 'shared.make_timestamp.php';
+    function smarty_modifier_date_format($string, $format = null, $default_date = '', $formatter = 'auto')
+    {
+        if ($format === null) {
+            $format = Smarty::$_DATE_FORMAT;
         }
-        $is_loaded = true;
-    }
-    if (!empty($string) && $string !== '0000-00-00' && $string !== '0000-00-00 00:00:00') {
-        $timestamp = smarty_make_timestamp($string);
-    } elseif (!empty($default_date)) {
-        $timestamp = smarty_make_timestamp($default_date);
-    } else {
-        return;
-    }
-    if ($formatter === 'strftime' || ($formatter === 'auto' && strpos($format, '%') !== false)) {
-        if (Smarty::$_IS_WINDOWS) {
-            $_win_from = array(
-                '%D',
-                '%h',
-                '%n',
-                '%r',
-                '%R',
-                '%t',
-                '%T'
-            );
-            $_win_to = array(
-                '%m/%d/%y',
-                '%b',
-                "\n",
-                '%I:%M:%S %p',
-                '%H:%M',
-                "\t",
-                '%H:%M:%S'
-            );
-            if (strpos($format, '%e') !== false) {
-                $_win_from[] = '%e';
-                $_win_to[] = sprintf('%\' 2d', date('j', $timestamp));
+        /**
+         * require_once the {@link shared.make_timestamp.php} plugin
+         */
+        static $is_loaded = false;
+        if (!$is_loaded) {
+            if (!is_callable('smarty_make_timestamp')) {
+                include_once SMARTY_PLUGINS_DIR . 'shared.make_timestamp.php';
             }
-            if (strpos($format, '%l') !== false) {
-                $_win_from[] = '%l';
-                $_win_to[] = sprintf('%\' 2d', date('h', $timestamp));
-            }
-            $format = str_replace($_win_from, $_win_to, $format);
+            $is_loaded = true;
         }
-        // @ to suppress deprecation errors when running in PHP8.1 or higher.
-        return @strftime($format, $timestamp);
-    } else {
-        return date($format, $timestamp);
+        if (!empty($string) && $string !== '0000-00-00' && $string !== '0000-00-00 00:00:00') {
+            $timestamp = smarty_make_timestamp($string);
+        } elseif (!empty($default_date)) {
+            $timestamp = smarty_make_timestamp($default_date);
+        } else {
+            return;
+        }
+        if ($formatter === 'strftime' || ($formatter === 'auto' && strpos($format, '%') !== false)) {
+            if (Smarty::$_IS_WINDOWS) {
+                $_win_from = array(
+                    '%D',
+                    '%h',
+                    '%n',
+                    '%r',
+                    '%R',
+                    '%t',
+                    '%T'
+                );
+                $_win_to = array(
+                    '%m/%d/%y',
+                    '%b',
+                    "\n",
+                    '%I:%M:%S %p',
+                    '%H:%M',
+                    "\t",
+                    '%H:%M:%S'
+                );
+                if (strpos($format, '%e') !== false) {
+                    $_win_from[] = '%e';
+                    $_win_to[] = sprintf('%\' 2d', date('j', $timestamp));
+                }
+                if (strpos($format, '%l') !== false) {
+                    $_win_from[] = '%l';
+                    $_win_to[] = sprintf('%\' 2d', date('h', $timestamp));
+                }
+                $format = str_replace($_win_from, $_win_to, $format);
+            }
+            // @ to suppress deprecation errors when running in PHP8.1 or higher.
+            return @strftime($format, $timestamp);
+        } else {
+            return date($format, $timestamp);
+        }
     }
 }


### PR DESCRIPTION
Since everything in `libs/` gets autoloaded by composer - there's no easy way to override built-in modifiers.

This is an attempt at a workaround for `date_format` specifically, as seen within [smarty_mb_str_replace](https://github.com/smarty-php/smarty/commit/8842e79107dd588fba782ca335133a3f0f70de98#diff-a07f3c868273f233caa2af211448d7b1bd52dd3eb7505f6f98543840d4108517R8)