### PR TITLE
Fix case-sensitive tag names (#907)

### DIFF
--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -464,7 +464,7 @@ class Template extends BaseCompiler {
 	public function compileTag($tag, $args, $parameter = []) {
 		$this->prefixCodeStack[] = $this->prefix_code;
 		$this->prefix_code = [];
-		$result = $this->compileTag2(strtolower($tag), $args, $parameter);
+		$result = $this->compileTag2($tag, $args, $parameter);
 		$this->prefix_code = array_merge($this->prefix_code, array_pop($this->prefixCodeStack));
 		return $result;
 	}
@@ -591,6 +591,7 @@ class Template extends BaseCompiler {
 	 * @return ?\Smarty\Compile\CompilerInterface tag compiler object or null if not found or untrusted by security policy
 	 */
 	public function getTagCompiler($tag): ?\Smarty\Compile\CompilerInterface {
+        $tag = strtolower($tag);
 
 		if (isset($this->smarty->security_policy) && !$this->smarty->security_policy->isTrustedTag($tag, $this)) {
 			return null;
@@ -1114,7 +1115,7 @@ class Template extends BaseCompiler {
 			}
 		}
 
-		// call to function previousely defined by {function} tag
+		// call to function previously defined by {function} tag
 		if ($this->canCompileTemplateFunctionCall($tag)) {
 
 			if (!empty($parameter['modifierlist'])) {

--- a/src/Security.php
+++ b/src/Security.php
@@ -261,6 +261,8 @@ class Security {
 	 * @return boolean                 true if tag is trusted
 	 */
 	public function isTrustedTag($tag_name, $compiler) {
+        $tag_name = strtolower($tag_name);
+
 		// check for internal always required tags
 		if (in_array($tag_name,	['assign', 'call'])) {
 			return true;

--- a/tests/UnitTests/SmartyMethodsTests/RegisterFunction/RegisterFunctionTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterFunction/RegisterFunctionTest.php
@@ -40,6 +40,17 @@ class RegisterFunctionTest extends PHPUnit_Smarty
     }
 
     /**
+     * test registerPlugin method for function case-sensitive
+     */
+    public function testRegisterFunctionCaseInsensitive()
+    {
+        $this->smarty->registerPlugin(Smarty::PLUGIN_FUNCTION, 'testFunction', 'myfunction');
+        $this->assertEquals('myfunction',
+            $this->smarty->getRegisteredPlugin(Smarty::PLUGIN_FUNCTION, 'testFunction')[0]);
+        $this->assertEquals('hello world 1', $this->smarty->fetch('eval:{testFunction value=1}'));
+    }
+
+    /**
      * test registerPlugin method for function  class
      */
     public function testRegisterFunctionClass()


### PR DESCRIPTION
This should fix #907. 

All tests pass, I thought about adding more tests for various plugins but it seemed overkill, happy to add them if the reviewer thinks otherwise. 

There might be a regression here (I don't think so) but just so everyone is aware this will start failing: 
```
$smarty = new Smarty();
$smarty->registerPlugin(Smarty::PLUGIN_FUNCTION, 'customtag', [Functions::class, 'customTag']);
$smarty->display('string:{customTag}');
```

I have kept the "built-in" tags case-insensitive because they have been relying on them being lowercase, so I think it is sensible to keep it this way. 