### PR TITLE
Fix Smarty::assign() not returning  when called 

### DIFF
--- a/changelog/972.md
+++ b/changelog/972.md
@@ -1,0 +1,1 @@
+- Fix Smarty::assign() not returning $this when called with an array as first parameter [#972](https://github.com/smarty-php/smarty/pull/972)

--- a/src/Data.php
+++ b/src/Data.php
@@ -109,7 +109,7 @@ class Data
             foreach ($tpl_var as $_key => $_val) {
                 $this->assign($_key, $_val, $nocache, $scope);
             }
-			return;
+			return $this;
         }
 		switch ($scope ?? $this->getDefaultScope()) {
 			case self::SCOPE_GLOBAL:

--- a/tests/UnitTests/SmartyMethodsTests/Assign/AssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/Assign/AssignTest.php
@@ -42,4 +42,15 @@ class AssignTest extends PHPUnit_Smarty
         $this->smarty->assign(array('foo' => 'bar', 'foo2' => 'bar2'));
         $this->assertEquals('bar bar2', $this->smarty->fetch('eval:{$foo} {$foo2}'));
     }
+
+	/**
+	 * Test that assign returns this.
+	 */
+	public function testAssignReturnsThis()
+	{
+		$this->assertEquals(
+			'data',
+			$this->smarty->assign(['dummy' => 'data'])->fetch('eval:{$dummy}')
+		);
+	}
 }


### PR DESCRIPTION
Fix Smarty::assign() not returning  when called with an array as first parameter.

Fixes #972