### PR TITLE
Fix docblock types

### DIFF
--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -535,8 +535,6 @@ class Smarty extends \Smarty\TemplateBase {
 	/**
 	 * Load an additional extension.
 	 *
-	 * @param Base $extension
-	 *
 	 * @return void
 	 */
 	public function addExtension(ExtensionInterface $extension) {
@@ -582,7 +580,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param string|\Smarty\Security $security_class if a string is used, it must be class-name
 	 *
-	 * @return Smarty                 current Smarty instance for chaining
+	 * @return static                 current Smarty instance for chaining
 	 * @throws \Smarty\Exception
 	 */
 	public function enableSecurity($security_class = null) {
@@ -593,7 +591,7 @@ class Smarty extends \Smarty\TemplateBase {
 	/**
 	 * Disable security
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function disableSecurity() {
 		$this->security_policy = null;
@@ -607,7 +605,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string $key of the array element to assign the template dir to
 	 * @param bool $isConfig true for config_dir
 	 *
-	 * @return Smarty          current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function addTemplateDir($template_dir, $key = null, $isConfig = false) {
 		if ($isConfig) {
@@ -672,7 +670,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string|array $template_dir directory(s) of template sources
 	 * @param bool $isConfig true for config_dir
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function setTemplateDir($template_dir, $isConfig = false) {
 		if ($isConfig) {
@@ -692,7 +690,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string|array $config_dir directory(s) of config sources
 	 * @param mixed $key key of the array element to assign the config dir to
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function addConfigDir($config_dir, $key = null) {
 		return $this->addTemplateDir($config_dir, $key, true);
@@ -714,7 +712,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param $config_dir
 	 *
-	 * @return Smarty       current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function setConfigDir($config_dir) {
 		return $this->setTemplateDir($config_dir, true);
@@ -788,7 +786,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param null|array|string $plugins_dir
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 * @deprecated since 5.0
 	 */
 	public function addPluginsDir($plugins_dir) {
@@ -821,7 +819,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param string|array $plugins_dir directory(s) of plugins
 	 *
-	 * @return Smarty       current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 * @deprecated since 5.0
 	 */
 	public function setPluginsDir($plugins_dir) {
@@ -882,7 +880,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param string $compile_dir directory to store compiled templates in
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function setCompileDir($compile_dir) {
 		$this->_normalizeDir('compile_dir', $compile_dir);
@@ -908,7 +906,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param string $cache_dir directory to store cached templates in
 	 *
-	 * @return Smarty current Smarty instance for chaining
+	 * @return static current Smarty instance for chaining
 	 */
 	public function setCacheDir($cache_dir) {
 		$this->_normalizeDir('cache_dir', $cache_dir);
@@ -1171,7 +1169,7 @@ class Smarty extends \Smarty\TemplateBase {
 	/**
 	 * Get Smarty object
 	 *
-	 * @return Smarty
+	 * @return static
 	 */
 	public function getSmarty() {
 		return $this;
@@ -1844,7 +1842,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string $type filter type
 	 * @param string $name filter name
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 * @api  Smarty::unloadFilter()
 	 *
@@ -1890,7 +1888,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string $name name of resource type
 	 * @param Base $resource_handler
 	 *
-	 * @return Smarty
+	 * @return static
 	 *
 	 * @api  Smarty::registerCacheResource()
 	 *
@@ -1911,7 +1909,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 *
 	 * @param                                                                 $name
 	 *
-	 * @return Smarty
+	 * @return static
 	 * @api  Smarty::unregisterCacheResource()
 	 *
 	 * @deprecated since 5.0
@@ -1944,7 +1942,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param callable $callback
 	 * @param string|null $name optional filter name
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 *
 	 * @api  Smarty::registerFilter()
@@ -2003,7 +2001,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param string $type filter type
 	 * @param callback|string $name the name previously used in ::registerFilter
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 * @api  Smarty::unregisterFilter()
 	 *
@@ -2040,7 +2038,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param array|string $modifiers modifier or list of modifiers
 	 *                                                                                   to add
 	 *
-	 * @return Smarty
+	 * @return static
 	 * @api Smarty::addDefaultModifiers()
 	 *
 	 */
@@ -2070,7 +2068,7 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @param array|string $modifiers modifier or list of modifiers
 	 *                                                                                   to set
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @api Smarty::setDefaultModifiers()
 	 *
 	 */

--- a/src/TemplateBase.php
+++ b/src/TemplateBase.php
@@ -73,7 +73,7 @@ abstract class TemplateBase extends Data {
 	 * @param bool $format smarty argument format, else traditional
 	 * @param array $block_methods list of block-methods
 	 *
-	 * @return \Smarty|\Smarty\Template
+	 * @return static
 	 * @throws \Smarty\Exception
 	 *
 	 * @api  Smarty::registerObject()
@@ -113,7 +113,7 @@ abstract class TemplateBase extends Data {
 	 *
 	 * @param string $object_name name of object
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @api  Smarty::unregisterObject()
 	 *
 	 */
@@ -251,7 +251,7 @@ abstract class TemplateBase extends Data {
 	 * @param array|string $literals literal or list of literals
 	 *                                                                                  to addto add
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 * @api Smarty::addLiterals()
 	 *
@@ -269,7 +269,7 @@ abstract class TemplateBase extends Data {
 	 * @param array|string $literals literal or list of literals
 	 *                                                                                  to setto set
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 * @api Smarty::setLiterals()
 	 *
@@ -312,7 +312,7 @@ abstract class TemplateBase extends Data {
 	 * @param string $class_impl the referenced PHP class to
 	 *                                                                                    register
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws \Smarty\Exception
 	 * @api  Smarty::registerClass()
 	 *
@@ -333,7 +333,7 @@ abstract class TemplateBase extends Data {
 	 *
 	 * @param callable $callback class/method name
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws Exception              if $callback is not callable
 	 * @api Smarty::registerDefaultConfigHandler()
 	 *
@@ -353,7 +353,7 @@ abstract class TemplateBase extends Data {
 	 *
 	 * @param callable $callback class/method name
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws Exception              if $callback is not callable
 	 * @api Smarty::registerDefaultTemplateHandler()
 	 *
@@ -374,7 +374,7 @@ abstract class TemplateBase extends Data {
 	 * @param string $name name of resource type
 	 * @param \Smarty\Resource\BasePlugin $resource_handler instance of Smarty\Resource\BasePlugin
 	 *
-	 * @return \Smarty\Smarty|\Smarty\Template
+	 * @return static
 	 *
 	 * @api  Smarty::registerResource()
 	 */
@@ -389,7 +389,7 @@ abstract class TemplateBase extends Data {
 	 *
 	 * @param string $type name of resource type
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @api  Smarty::unregisterResource()
 	 *
 	 */
@@ -406,7 +406,7 @@ abstract class TemplateBase extends Data {
 	 *
 	 * @param string $tpl_name
 	 *
-	 * @return TemplateBase
+	 * @return static
 	 * @throws Exception if file is not readable
 	 * @api Smarty::setDebugTemplate()
 	 *


### PR DESCRIPTION
This PR fixes a couple of `UndefinedDocblockClass` issues that Psalm was throwing after the upgrade to version 5.

@wisskid Nice work on the new version 😄 I know you've caught some flack for some of the changes, but they are all for the good. We payed attention to the deprecation notices in v4 so it's gone smoothly (so far 🤞)