### PR TITLE
add missing closing tr tag

### DIFF
--- a/src/debug.tpl
+++ b/src/debug.tpl
@@ -144,6 +144,7 @@
                         {$vars['attributes']|debug_print_var nofilter}
                     {/if}
                 </td>
+            </tr>
          {/foreach}
     </table>
 


### PR DESCRIPTION
add missing end </tr> tag for 'assigned template variables' section.
it's also missing for the 4.x branch.