### PR TITLE
Add PHP 8.4 support to Smarty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
         compiler:
           - default
@@ -49,6 +50,9 @@ jobs:
             compiler: jit
           - os: ubuntu-latest
             php-version: "8.3"
+            compiler: jit
+          - os: ubuntu-latest
+            php-version: "8.4"
             compiler: jit
 
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Smarty is a template engine for PHP, facilitating the separation of presentation
 Read the [documentation](https://smarty-php.github.io/smarty/) to find out how to use it. 
 
 ## Requirements
-Smarty v5 can be run with PHP 7.2 to PHP 8.3.
+Smarty v5 can be run with PHP 7.2 to PHP 8.4.
 
 ## Installation
 Smarty versions 3.1.11 or later can be installed with [Composer](https://getcomposer.org/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,11 @@ services:
       service: base
     build:
       dockerfile: ./utilities/testrunners/php83/Dockerfile
+  php84:
+    extends:
+      service: base
+    build:
+      dockerfile: ./utilities/testrunners/php84/Dockerfile
 volumes:
   smarty-code:
 

--- a/run-tests-for-all-php-versions.sh
+++ b/run-tests-for-all-php-versions.sh
@@ -14,3 +14,4 @@ $COMPOSE_CMD run --rm php80 ./run-tests.sh $@ && \
 $COMPOSE_CMD run --rm php81 ./run-tests.sh $@ && \
 $COMPOSE_CMD run --rm php82 ./run-tests.sh $@
 $COMPOSE_CMD run --rm php83 ./run-tests.sh $@
+$COMPOSE_CMD run --rm php84 ./run-tests.sh $@

--- a/src/Cacheresource/Base.php
+++ b/src/Cacheresource/Base.php
@@ -44,7 +44,7 @@ abstract class Base
 	 */
     abstract public function process(
 	    Template $_template,
-	    Cached   $cached = null,
+	    ?Cached  $cached = null,
 	             $update = false
     );
 

--- a/src/Cacheresource/Custom.php
+++ b/src/Cacheresource/Custom.php
@@ -139,7 +139,7 @@ abstract class Custom extends Base
 	 */
     public function process(
 	    Template               $_smarty_tpl,
-	    \Smarty\Template\Cached $cached = null,
+	    ?\Smarty\Template\Cached $cached = null,
 	                           $update = false
     ) {
         if (!$cached) {

--- a/src/Cacheresource/File.php
+++ b/src/Cacheresource/File.php
@@ -99,7 +99,7 @@ class File extends Base
 	 */
     public function process(
 	    Template $_smarty_tpl,
-	    Cached   $cached = null,
+	    ?Cached  $cached = null,
 	             $update = false
     ) {
         $_smarty_tpl->getCached()->setValid(false);

--- a/src/Cacheresource/KeyValueStore.php
+++ b/src/Cacheresource/KeyValueStore.php
@@ -103,7 +103,7 @@ abstract class KeyValueStore extends Base
 	 */
     public function process(
 	    Template $_smarty_tpl,
-	    Cached   $cached = null,
+	    ?Cached  $cached = null,
 	             $update = false
     ) {
         if (!$cached) {

--- a/src/Compiler/CodeFrame.php
+++ b/src/Compiler/CodeFrame.php
@@ -41,7 +41,7 @@ class CodeFrame
         $content = '',
         $functions = '',
         $cache = false,
-        \Smarty\Compiler\Template $compiler = null
+        ?\Smarty\Compiler\Template $compiler = null
     ) {
         // build property code
         $properties[ 'version' ] = \Smarty\Smarty::SMARTY_VERSION;

--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -374,7 +374,7 @@ class Template extends BaseCompiler {
 	 * @throws CompilerException
 	 * @throws Exception
 	 */
-	public function compileTemplateSource(\Smarty\Template $template, \Smarty\Compiler\Template $parent_compiler = null) {
+	public function compileTemplateSource(\Smarty\Template $template, ?\Smarty\Compiler\Template $parent_compiler = null) {
 		try {
 			// save template object in compiler class
 			$this->template = $template;

--- a/src/CompilerException.php
+++ b/src/CompilerException.php
@@ -16,14 +16,14 @@ class CompilerException extends Exception {
 	 * @param int $code The Exception code.
 	 * @param string|null $filename The filename where the exception is thrown.
 	 * @param int|null $line The line number where the exception is thrown.
-	 * @param Throwable|null $previous The previous exception used for the exception chaining.
+	 * @param \Throwable|null $previous The previous exception used for the exception chaining.
 	 */
 	public function __construct(
 		string    $message = "",
 		int       $code = 0,
 		?string   $filename = null,
 		?int      $line = null,
-		Throwable $previous = null
+		?\Throwable $previous = null
 	) {
 		parent::__construct($message, $code, $previous);
 

--- a/src/Resource/BasePlugin.php
+++ b/src/Resource/BasePlugin.php
@@ -112,7 +112,7 @@ abstract class BasePlugin
 	 * @param Source $source source object
 	 * @param Template|null $_template template object
 	 */
-    abstract public function populate(Source $source, \Smarty\Template $_template = null);
+    abstract public function populate(Source $source, ?\Smarty\Template $_template = null);
 
     /**
      * populate Source Object with timestamp and exists from Resource

--- a/src/Resource/CustomPlugin.php
+++ b/src/Resource/CustomPlugin.php
@@ -50,7 +50,7 @@ abstract class CustomPlugin extends BasePlugin {
 	 * @param Source $source source object
 	 * @param Template|null $_template template object
 	 */
-	public function populate(Source $source, Template $_template = null) {
+	public function populate(Source $source, ?Template $_template = null) {
 		$source->uid = sha1($source->type . ':' . $source->name);
 		$mtime = $this->fetchTimestamp($source->name);
 		if ($mtime !== null) {

--- a/src/Resource/ExtendsPlugin.php
+++ b/src/Resource/ExtendsPlugin.php
@@ -23,7 +23,7 @@ class ExtendsPlugin extends BasePlugin
      *
      * @throws Exception
      */
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $uid = '';
         $sources = array();

--- a/src/Resource/FilePlugin.php
+++ b/src/Resource/FilePlugin.php
@@ -32,7 +32,7 @@ class FilePlugin extends BasePlugin {
 	 *
 	 * @throws Exception
 	 */
-	public function populate(Source $source, Template $_template = null) {
+	public function populate(Source $source, ?Template $_template = null) {
 
 		$source->uid = sha1(
 			$source->name . ($source->isConfig ? $source->getSmarty()->_joined_config_dir :

--- a/src/Resource/StreamPlugin.php
+++ b/src/Resource/StreamPlugin.php
@@ -33,7 +33,7 @@ class StreamPlugin extends RecompiledPlugin {
 	 *
 	 * @return void
 	 */
-	public function populate(Source $source, Template $_template = null) {
+	public function populate(Source $source, ?Template $_template = null) {
 		$source->uid = false;
 		$source->content = $this->getContent($source);
 		$source->timestamp = $source->exists = !!$source->content;

--- a/src/Resource/StringPlugin.php
+++ b/src/Resource/StringPlugin.php
@@ -31,7 +31,7 @@ class StringPlugin extends BasePlugin {
 	 *
 	 * @return void
 	 */
-	public function populate(Source $source, Template $_template = null) {
+	public function populate(Source $source, ?Template $_template = null) {
 		$source->uid = sha1($source->name);
 		$source->timestamp = $source->exists = true;
 	}

--- a/src/Runtime/InheritanceRuntime.php
+++ b/src/Runtime/InheritanceRuntime.php
@@ -162,7 +162,7 @@ class InheritanceRuntime {
 	private function processBlock(
 		Template              $tpl,
 		\Smarty\Runtime\Block $block,
-		\Smarty\Runtime\Block $parent = null
+		?\Smarty\Runtime\Block $parent = null
 	) {
 		if ($block->hide && !isset($block->child)) {
 			return;

--- a/src/Template.php
+++ b/src/Template.php
@@ -115,7 +115,7 @@ class Template extends TemplateBase {
 	public function __construct(
 		$template_resource,
 		Smarty $smarty,
-		\Smarty\Data $_parent = null,
+		?\Smarty\Data $_parent = null,
 		$_cache_id = null,
 		$_compile_id = null,
 		$_caching = null,
@@ -248,7 +248,7 @@ class Template extends TemplateBase {
 		$caching,
 		$cache_lifetime,
 		array $extra_vars = [],
-		int $scope = null,
+		?int $scope = null,
 		?string $currentDir = null
 	) {
 
@@ -462,7 +462,7 @@ class Template extends TemplateBase {
 	 * @return string
 	 * @throws Exception
 	 */
-	public function createCodeFrame($content = '', $functions = '', $cache = false, \Smarty\Compiler\Template $compiler = null) {
+	public function createCodeFrame($content = '', $functions = '', $cache = false, ?\Smarty\Compiler\Template $compiler = null) {
 		return $this->getCodeFrameCompiler()->create($content, $functions, $cache, $compiler);
 	}
 

--- a/src/Template/Source.php
+++ b/src/Template/Source.php
@@ -134,9 +134,9 @@ class Source {
 	 * @throws Exception
 	 */
 	public static function load(
-		Template $_template = null,
-		Smarty   $smarty = null,
-		         $template_resource = null
+		?Template $_template = null,
+		?Smarty   $smarty = null,
+		          $template_resource = null
 	) {
 		if ($_template) {
 			$smarty = $_template->getSmarty();

--- a/src/TemplateBase.php
+++ b/src/TemplateBase.php
@@ -179,7 +179,7 @@ abstract class TemplateBase extends Data {
 	 * @api  Smarty::createData()
 	 *
 	 */
-	public function createData(Data $parent = null, $name = null) {
+	public function createData(?Data $parent = null, $name = null) {
 		/* @var Smarty $smarty */
 		$smarty = $this->getSmarty();
 		$dataObj = new Data($parent, $smarty, $name);

--- a/tests/PHPUnit_Smarty.php
+++ b/tests/PHPUnit_Smarty.php
@@ -64,7 +64,7 @@ class PHPUnit_Smarty extends PHPUnit\Framework\TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+        error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
         self::$init = true;
         self::$pluginsdir =self::getSmartyPluginsDir();
     }

--- a/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
@@ -12,7 +12,7 @@ class Smarty_Resource_FiletestPlugin extends FilePlugin
      * @param Source   $source    source object
      * @param Template $_template template object
      */
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         parent::populate($source, $_template);
         if ($source->exists) {

--- a/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
+++ b/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
@@ -34,7 +34,7 @@ class Smarty_Resource_AmbiguousPlugin extends FilePlugin
      * @param Source   $source    source object
      * @param Template $_template template object
      */
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $segment = '';
         if ($this->segment) {

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
@@ -16,7 +16,7 @@ use Smarty\Template\Source;
 
 class Smarty_Resource_Db extends RecompiledPlugin {
 
-    public function populate(Source $source, Template $_template = null) {
+    public function populate(Source $source, ?Template $_template = null) {
         $source->uid = sha1($source->resource);
         $source->timestamp = 1000000000;
         $source->exists = true;

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
@@ -16,7 +16,7 @@ use Smarty\Template\Source;
 
 class Smarty_Resource_Db2 extends RecompiledPlugin
 {
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $source->uid = sha1($source->resource);
         $source->timestamp = 0;

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
@@ -15,7 +15,7 @@ use Smarty\Template\Source;
 
 class Smarty_Resource_Db3 extends Smarty\Resource\BasePlugin
 {
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $source->uid = sha1($source->resource);
         $source->timestamp = 0;

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
@@ -16,7 +16,7 @@ use Smarty\Template\Source;
 
 class Smarty_Resource_Db4 extends Smarty\Resource\BasePlugin
 {
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $source->uid = sha1($source->resource);
         $source->timestamp = 0;

--- a/tests/UnitTests/__shared/resources/resource.extendsall.php
+++ b/tests/UnitTests/__shared/resources/resource.extendsall.php
@@ -22,7 +22,7 @@ class My_Resource_Extendsall extends \Smarty\Resource\ExtendsPlugin
      *
      * @return void
      */
-    public function populate(Source $source, Template $_template = null)
+    public function populate(Source $source, ?Template $_template = null)
     {
         $uid = '';
         $sources = array();

--- a/utilities/testrunners/php84/Dockerfile
+++ b/utilities/testrunners/php84/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.4-rc-cli-bullseye
+
+## Basic utilities
+RUN apt-get update -yqq && apt-get install -y curl apt-utils git zip unzip
+
+## Composer
+COPY ./utilities/testrunners/shared/install-composer.sh /root/install-composer.sh
+WORKDIR /root
+RUN sh ./install-composer.sh
+RUN mv ./composer.phar /usr/local/bin/composer


### PR DESCRIPTION
This pull request updates the code base to support the deprecations introduced in PHP 8.4. It should be backwards compatible.

1. Updated the function signatures that had implicit null assignment to typed parameters. 
2. Added PHP 8.4 to the 'run tests'-shell script.
3. Bumped the PHP version in the README.md 
