### PR TITLE
Fixing forced OpCache invalidation on every template include, which is resulting in fast raising wasted OpCache memory #1007

### DIFF
--- a/src/Resource/FilePlugin.php
+++ b/src/Resource/FilePlugin.php
@@ -56,12 +56,14 @@ class FilePlugin extends BasePlugin {
 	 * @param Source $source source object
 	 */
 	public function populateTimestamp(Source $source) {
-		$path = false;
-		if (!$source->exists && $path = $this->getFilePath($source->name, $source->getSmarty(), $source->isConfig)) {
-			$source->timestamp = $source->exists = is_file($path);
+		$path = $this->getFilePath($source->name, $source->getSmarty(), $source->isConfig);
+		if (!$source->exists) {
+			$source->exists = ($path !== false && is_file($path));
 		}
-		if ($source->exists && $path) {
+		if ($source->exists && $path !== false) {
 			$source->timestamp = filemtime($path);
+		} else {
+			$source->timestamp = 0;
 		}
 	}
 

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -248,7 +248,7 @@ class Compiled extends GeneratedPhpFile {
 		if (function_exists('opcache_invalidate')
 			&& (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
 		) {
-			opcache_invalidate($this->filepath, true);
+			opcache_invalidate($this->filepath, false);
 		} elseif (function_exists('apc_compile_file')) {
 			apc_compile_file($this->filepath);
 		}

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -241,7 +241,7 @@ class Compiled extends GeneratedPhpFile {
 	 * HHVM requires a workaround because of a PHP incompatibility
 	 *
 	 * @param Template $_smarty_tpl do not change/remove variable name, is used by compiled template
-	 * @param bool $invalidateCachedFiles
+	 * @param bool $invalidateCachedFiles forces a revalidation of the file in opcache or apc cache (if available)
 	 *
 	 */
 	private function loadCompiledTemplate(Template $_smarty_tpl, bool $invalidateCachedFiles = true) {

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -246,14 +246,14 @@ class Compiled extends GeneratedPhpFile {
 	 */
 	private function loadCompiledTemplate(Template $_smarty_tpl, bool $invalidateCachedFiles = true) {
         
-        if ($invalidateCachedFiles) {
-            if (function_exists('opcache_invalidate')
-                && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
-            ) {
-                opcache_invalidate($this->filepath, false);
-            } elseif (function_exists('apc_compile_file')) {
-                apc_compile_file($this->filepath);
-            }
+		if ($invalidateCachedFiles) {
+			if (function_exists('opcache_invalidate')
+				 && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
+			) {
+				opcache_invalidate($this->filepath, false);
+			} elseif (function_exists('apc_compile_file')) {
+				apc_compile_file($this->filepath);
+			}
         }
 		if (defined('HHVM_VERSION')) {
 			eval('?>' . file_get_contents($this->filepath));

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -254,7 +254,7 @@ class Compiled extends GeneratedPhpFile {
 			} elseif (function_exists('apc_compile_file')) {
 				apc_compile_file($this->filepath);
 			}
-        }
+		}
 		if (defined('HHVM_VERSION')) {
 			eval('?>' . file_get_contents($this->filepath));
 		} else {

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -250,7 +250,7 @@ class Compiled extends GeneratedPhpFile {
 			if (function_exists('opcache_invalidate')
 				 && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
 			) {
-				opcache_invalidate($this->filepath, false);
+				opcache_invalidate($this->filepath, true);
 			} elseif (function_exists('apc_compile_file')) {
 				apc_compile_file($this->filepath);
 			}

--- a/src/Template/Compiled.php
+++ b/src/Template/Compiled.php
@@ -136,7 +136,7 @@ class Compiled extends GeneratedPhpFile {
 		if ($this->exists && !$_smarty_tpl->getSmarty()->force_compile
 			&& !($_smarty_tpl->compile_check && $_smarty_tpl->getSource()->getTimeStamp() > $this->getTimeStamp())
 		) {
-			$this->loadCompiledTemplate($_smarty_tpl);
+			$this->loadCompiledTemplate($_smarty_tpl, false);
 		}
 
 		if (!$this->isValid) {
@@ -241,17 +241,20 @@ class Compiled extends GeneratedPhpFile {
 	 * HHVM requires a workaround because of a PHP incompatibility
 	 *
 	 * @param Template $_smarty_tpl do not change/remove variable name, is used by compiled template
+	 * @param bool $invalidateCachedFiles
 	 *
 	 */
-	private function loadCompiledTemplate(Template $_smarty_tpl) {
-
-		if (function_exists('opcache_invalidate')
-			&& (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
-		) {
-			opcache_invalidate($this->filepath, false);
-		} elseif (function_exists('apc_compile_file')) {
-			apc_compile_file($this->filepath);
-		}
+	private function loadCompiledTemplate(Template $_smarty_tpl, bool $invalidateCachedFiles = true) {
+        
+        if ($invalidateCachedFiles) {
+            if (function_exists('opcache_invalidate')
+                && (!function_exists('ini_get') || strlen(ini_get("opcache.restrict_api")) < 1)
+            ) {
+                opcache_invalidate($this->filepath, false);
+            } elseif (function_exists('apc_compile_file')) {
+                apc_compile_file($this->filepath);
+            }
+        }
 		if (defined('HHVM_VERSION')) {
 			eval('?>' . file_get_contents($this->filepath));
 		} else {


### PR DESCRIPTION
Fixes: https://github.com/smarty-php/smarty/issues/1007

\Smarty\Template\Compiled::loadCompiledTemplate invalidates the cache entry of a compiled template on every call (or include) as it is forced to do so.
This results in fast growing wasted memory and after reaching the tipping point in a total cleanup and refresh of the opcache.

I do not think, that is necessary to force it, seeing this change as hotfix.
 
Nice article about wasted memory of the opcache and it's refreshment mechanism: 
https://www.codana.be/en/insights/php-opcache-realpath-cache-and-preloading

