### PR TITLE
Allow built-in modifiers override

### DIFF
--- a/src/Extension/DefaultExtension.php
+++ b/src/Extension/DefaultExtension.php
@@ -6,13 +6,26 @@ use Smarty\Exception;
 
 class DefaultExtension extends Base {
 
+    /**
+     * @var \Smarty\Smarty
+     */
+    private $smarty;
+
 	private $modifiers = [];
 
 	private $functionHandlers = [];
 
 	private $blockHandlers = [];
 
+    public function __construct(\Smarty\Smarty $smarty) {
+        $this->smarty = $smarty;
+    }
+
 	public function getModifierCompiler(string $modifier): ?\Smarty\Compile\Modifier\ModifierCompilerInterface {
+
+        if($this->smarty->getRegisteredPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, $modifier) ?? $this->smarty->getRegisteredPlugin(\Smarty\Smarty::PLUGIN_MODIFIERCOMPILER, $modifier)) {
+            return null;
+        }
 
 		if (isset($this->modifiers[$modifier])) {
 			return $this->modifiers[$modifier];
@@ -53,7 +66,12 @@ class DefaultExtension extends Base {
 	}
 
 	public function getModifierCallback(string $modifierName) {
-		switch ($modifierName) {
+
+        if ($this->smarty->getRegisteredPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, $modifierName)){
+            return null;
+        }
+
+        switch ($modifierName) {
 			case 'capitalize': return [$this, 'smarty_modifier_capitalize'];
 			case 'count': return [$this, 'smarty_modifier_count'];
 			case 'date_format': return [$this, 'smarty_modifier_date_format'];

--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -526,7 +526,7 @@ class Smarty extends \Smarty\TemplateBase {
 		$this->BCPluginsAdapter = new BCPluginsAdapter($this);
 
 		$this->extensions[] = new CoreExtension();
-		$this->extensions[] = new DefaultExtension();
+		$this->extensions[] = new DefaultExtension($this);
 		$this->extensions[] = $this->BCPluginsAdapter;
 
 		$this->cacheResource = new File();


### PR DESCRIPTION
A proposition to fix #1048 (and may be a part of #1011 too)

This is to prevent modifiers added by registerPlugin function from beeing silently ignored by DefaultExtension.
More details in #1048