### PR TITLE
Php 8.4 support preparation (partial)

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -462,7 +462,7 @@ class Template extends TemplateBase {
 	 * @return string
 	 * @throws Exception
 	 */
-	public function createCodeFrame($content = '', $functions = '', $cache = false, \Smarty\Compiler\Template $compiler = null) {
+	public function createCodeFrame($content = '', $functions = '', $cache = false, ?\Smarty\Compiler\Template $compiler = null) {
 		return $this->getCodeFrameCompiler()->create($content, $functions, $cache, $compiler);
 	}
 


### PR DESCRIPTION
When running unit tests on php 8.4 I see

```
Deprecated: Smarty\Template::createCodeFrame(): Implicitly marking parameter $compiler as nullable is deprecated, the explicit nullable type must be used instead in /home/homer/buildkit/build/build-2/web/core/packages/smarty5/vendor/smarty/smarty/src/Template.php on line 465
```

There is a more complete PR - which I endorse https://github.com/smarty-php/smarty/pull/1043