### PR TITLE
Fix unit tests to enable to run CacheResourceFileTest.php on Windows

### DIFF
--- a/tests/UnitTests/CacheResourceTests/File/CacheResourceFileTest.php
+++ b/tests/UnitTests/CacheResourceTests/File/CacheResourceFileTest.php
@@ -14,10 +14,13 @@ include_once __DIR__ . '/../_shared/CacheResourceTestCommon.php';
 class CacheResourceFileTest extends CacheResourceTestCommon
 {
 
+    private $directorySeparator;
+
     public function setUp(): void
     {
         $this->setUpSmarty(__DIR__);
         parent::setUp();
+        $this->directorySeparator = preg_quote(DIRECTORY_SEPARATOR, '/');
         $this->smarty->setCachingType('filetest');
     }
 
@@ -38,7 +41,8 @@ class CacheResourceFileTest extends CacheResourceTestCommon
         $this->smarty->setUseSubDirs(true);
         $tpl = $this->smarty->createTemplate('helloworld.tpl');
 
-		$this->assertRegExp('/.*\/([a-f0-9]{2}\/){3}.*.php/', $tpl->getCached()->filepath);
+        $pattern = '/.*' . $this->directorySeparator . '([a-f0-9]{2}' . $this->directorySeparator . '){3}.*\.php/';
+        $this->assertRegExp($pattern, $tpl->getCached()->filepath);
     }
 
     /**
@@ -51,7 +55,8 @@ class CacheResourceFileTest extends CacheResourceTestCommon
         $this->smarty->setUseSubDirs(true);
         $tpl = $this->smarty->createTemplate('helloworld.tpl', 'foo|bar');
 
-	    $this->assertRegExp('/.*\/foo\/bar\/([a-f0-9]{2}\/){3}.*.php/', $tpl->getCached()->filepath);
+        $pattern = '/.*' . $this->directorySeparator . 'foo' . $this->directorySeparator . 'bar' . $this->directorySeparator . '([a-f0-9]{2}' . $this->directorySeparator . '){3}.*\.php/';
+        $this->assertRegExp($pattern, $tpl->getCached()->filepath);
     }
 
     /**
@@ -63,7 +68,9 @@ class CacheResourceFileTest extends CacheResourceTestCommon
         $this->smarty->cache_lifetime = 1000;
         $this->smarty->setUseSubDirs(true);
         $tpl = $this->smarty->createTemplate('helloworld.tpl', null, 'blar');
-	    $this->assertRegExp('/.*\/blar\/([a-f0-9]{2}\/){3}.*.php/', $tpl->getCached()->filepath);
+
+        $pattern = '/.*' . $this->directorySeparator . 'blar' . $this->directorySeparator . '([a-f0-9]{2}' . $this->directorySeparator . '){3}.*\.php/';
+        $this->assertRegExp($pattern, $tpl->getCached()->filepath);
     }
 
     /**
@@ -75,7 +82,9 @@ class CacheResourceFileTest extends CacheResourceTestCommon
         $this->smarty->cache_lifetime = 1000;
         $this->smarty->setUseSubDirs(true);
         $tpl = $this->smarty->createTemplate('helloworld.tpl', 'foo|bar', 'blar');
-	    $this->assertRegExp('/.*\/foo\/bar\/blar\\/([a-f0-9]{2}\/){3}.*.php/', $tpl->getCached()->filepath);
+
+        $pattern = '/.*' . $this->directorySeparator . 'foo' . $this->directorySeparator . 'bar' . $this->directorySeparator . 'blar' . $this->directorySeparator . '([a-f0-9]{2}' . $this->directorySeparator . '){3}.*\.php/';
+        $this->assertRegExp($pattern, $tpl->getCached()->filepath);
     }
 
     /**


### PR DESCRIPTION
This PR fixes unit tests to enable to run CacheResourceFileTest.php on Windows. (Related PR: #1046 )
Some unit tests in CacheResourceFileTest.php now take the directory separator of Windows into account.

Test Results after modification:
```
> php .\vendor\phpunit\phpunit\phpunit --filter=CacheResourceFileTest
PHPUnit 8.5.39 by Sebastian Bergmann and contributors.

...............................................................   63 / 63 (100%)

Time: 56.96 seconds, Memory: 18.00 MB

OK (63 tests, 258 assertions)
```

Current Test Results:
(from https://github.com/smarty-php/smarty/pull/1046#issuecomment-2257067168 )
```
1) CacheResourceFileTest::testGetCachedFilepathSubDirs
Failed asserting that 'D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\cache\ca\25\46\ca2546820bc1a72783da84062884d71d8e3c1ff4_helloworld.tpl.php' matches PCRE pattern "/.*\/([a-f0-9]{2}\/){3}.*.php/".

D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\CacheResourceFileTest.php:41

2) CacheResourceFileTest::testGetCachedFilepathCacheId
Failed asserting that 'D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\cache\foo\bar\ca\25\46\ca2546820bc1a72783da84062884d71d8e3c1ff4_helloworld.tpl.php' matches PCRE pattern "/.*\/foo\/bar\/([a-f0-9]{2}\/){3}.*.php/".

D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\CacheResourceFileTest.php:54

3) CacheResourceFileTest::testGetCachedFilepathCompileId
Failed asserting that 'D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\cache\blar\ca\25\46\ca2546820bc1a72783da84062884d71d8e3c1ff4_helloworld.tpl.php' matches PCRE pattern "/.*\/blar\/([a-f0-9]{2}\/){3}.*.php/".

D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\CacheResourceFileTest.php:66

4) CacheResourceFileTest::testGetCachedFilepathCacheIdCompileId
Failed asserting that 'D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\cache\foo\bar\blar\ca\25\46\ca2546820bc1a72783da84062884d71d8e3c1ff4_helloworld.tpl.php' matches PCRE pattern "/.*\/foo\/bar\/blar\/([a-f0-9]{2}\/){3}.*.php/".

D:\a\smarty\smarty\tests\UnitTests\CacheResourceTests\File\CacheResourceFileTest.php:78
```