### PR TITLE
Fix an issue that preventing the use of "extends:" to define the inheritance tree on Windows

### DIFF
--- a/src/Resource/ExtendsPlugin.php
+++ b/src/Resource/ExtendsPlugin.php
@@ -93,7 +93,11 @@ class ExtendsPlugin extends BasePlugin
      */
     public function getBasename(Source $source)
     {
-        return str_replace(':', '.', basename($source->getResourceName()));
+        $search = array(':');
+        if (\Smarty\Smarty::$_IS_WINDOWS) {
+            $search = array(':', '|');
+        }
+        return str_replace($search, '.', basename($source->getResourceName()));
     }
 
     /*


### PR DESCRIPTION
This PR fixes #1018 
And many of the errors detected by https://github.com/smarty-php/smarty/pull/1046#issuecomment-2257067168 will be corrected, too.


The filename in https://github.com/smarty-php/smarty/issues/1018#issuecomment-2137617407 will have “|” replaced by “.”  as follows on Windows only:

[Before]
- ./tests/UnitTests/ResourceTests/Extends/templates_c/0a382e517fefa510de3f987160291ed9924a7124_0.extends_050_parent.tpl|050_child.tpl|050_grandchild.tpl.php

[After]
- ./tests/UnitTests/ResourceTests/Extends/templates_c/0a382e517fefa510de3f987160291ed9924a7124_0.extends_050_parent.tpl.050_child.tpl.050_grandchild.tpl.php


How about this fix?
This feels like a quick fix, but seems to solve the issue on Windows.
If we try to match the behavior to v4, the fix will take a bit more work.


(Updated  on August 29, 2024) Corrected the result of [After].