### PR TITLE
Fix unit tests to enable to run NullCoalescingTest.php and TernaryTest.php on Windows

### DIFF
--- a/tests/UnitTests/TemplateSource/NullCoalescingTest.php
+++ b/tests/UnitTests/TemplateSource/NullCoalescingTest.php
@@ -4,7 +4,7 @@ class NullCoalescingTest extends PHPUnit_Smarty {
 
 	public function setUp(): void
 	{
-		$this->setUpSmarty('/tmp');
+		$this->setUpSmarty(sys_get_temp_dir());
 		$this->cleanDirs();
 	}
 

--- a/tests/UnitTests/TemplateSource/TernaryTest.php
+++ b/tests/UnitTests/TemplateSource/TernaryTest.php
@@ -4,7 +4,7 @@ class TernaryTest extends PHPUnit_Smarty {
 
 	public function setUp(): void
 	{
-		$this->setUpSmarty('/tmp');
+		$this->setUpSmarty(sys_get_temp_dir());
 		$this->cleanDirs();
 	}
 


### PR DESCRIPTION
This PR fixes unit tests to enable to run NullCoalescingTest.php and TernaryTest.php on Windows. (Related PR: #1046 )


Current Test Results:
(from https://github.com/smarty-php/smarty/pull/1046#issuecomment-2257067168 )
```
45) NullCoalescingTest::testUndefined
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\NullCoalescingTest.php:7

46) NullCoalescingTest::testOther with data set #0 (null, 'undefined')
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\NullCoalescingTest.php:7

47) NullCoalescingTest::testOther with data set #1 ('blah', 'blah')
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\NullCoalescingTest.php:7

48) NullCoalescingTest::testOther with data set #2 ('', '')
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\NullCoalescingTest.php:7

49) NullCoalescingTest::testOther with data set #3 (false, false)
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\NullCoalescingTest.php:7

50) TernaryTest::testTernaryTrue
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\TernaryTest.php:7

51) TernaryTest::testTernaryFalse
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\TernaryTest.php:7

52) TernaryTest::testShorthandTernaryTrue
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\TernaryTest.php:7

53) TernaryTest::testShorthandTernaryFalse
chdir(): No such file or directory (errno 2)

D:\a\smarty\smarty\tests\PHPUnit_Smarty.php:107
D:\a\smarty\smarty\tests\UnitTests\TemplateSource\TernaryTest.php:7
```