### PR TITLE
Smarty 4 Suppress Deprecation Notices for Unregistered Callables in Templates using muteUndefinedOrNullWarnings function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.5] - 2024-09-18
+- smarty 4 suppresses Smarty register class-plugin error in muteUndefinedOrNullWarnings function
+
 ## [4.5.4] - 2024-08-14
 - Fixed that using `count()` would trigger a deprecation notice. [#813](https://github.com/smarty-php/smarty/issues/813)
 

--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -30,6 +30,18 @@ class Smarty_Internal_ErrorHandler
     public $allowUndefinedArrayKeys = true;
 
     /**
+     * Allows Unregistered smarty Plugin.
+     * @var bool
+     */
+    public $allowUnregisteredPlugin = true;
+
+    /**
+     * Allows Unregistered smarty class.
+     * @var bool
+     */
+    public $allowUnregisteredClass = true;
+
+    /**
      * Allows {$foo->bar} where bar is not an object (e.g. null or false).
      * @var bool
      */
@@ -105,6 +117,21 @@ class Smarty_Internal_ErrorHandler
                 $errstr
             )) {
             return; // suppresses this error
+        }
+
+        if ($this->allowUnregisteredPlugin && preg_match(
+                '/Use Smarty::registerPlugin/',
+                $errstr
+            )) {
+            return; // suppresses this error
+        }
+
+
+        if ($this->allowUnregisteredClass && preg_match(
+            '/Use Smarty::registerClass/',
+            $errstr
+          )) {
+          return; // suppresses this error
         }
 
         // pass all other errors through to the previous error handler or to the default PHP error handler


### PR DESCRIPTION
Hi @wisskid

As per discussion [#967](https://github.com/smarty-php/smarty/discussions/967), Smarty 4.5 has introduced deprecation notices to warn users about the usage of unregistered callables in templates. 

To prevent these warnings from cluttering the logs, we've implemented a fix that suppresses these deprecation notices by utilizing the muteUndefinedOrNullWarnings function for Smarty 4.5.

This change ensures that deprecated notices for unregistered callables are properly handled, preventing unnecessary interruptions 
 in Smarty 4.5.