### PR TITLE
Add PHP 8.4 support to Smarty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
         compiler:
           - default
@@ -49,6 +50,9 @@ jobs:
             compiler: jit
           - os: ubuntu-latest
             php-version: "8.3"
+            compiler: jit
+          - os: ubuntu-latest
+            php-version: "8.4"
             compiler: jit
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Smarty is a template engine for PHP, facilitating the separation of presentation
 Read the [documentation](https://smarty-php.github.io/smarty/) to find out how to use it. 
 
 ## Requirements
-Smarty can be run with PHP 7.1 to PHP 8.3.
+Smarty can be run with PHP 7.1 to PHP 8.4.
 
 ## Installation
 Smarty versions 3.1.11 or later can be installed with [Composer](https://getcomposer.org/).

--- a/demo/plugins/resource.extendsall.php
+++ b/demo/plugins/resource.extendsall.php
@@ -13,12 +13,12 @@ class Smarty_Resource_Extendsall extends Smarty_Internal_Resource_Extends
     /**
      * populate Source Object with meta data from Resource
      *
-     * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Template_Source        $source    source object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $uid = '';
         $sources = array();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,9 @@ services:
     extends:
       service: base
     build:
-      dockerfile: ./utilities/testrunners/php83/Dockerfile 
+      dockerfile: ./utilities/testrunners/php83/Dockerfile
+  php84:
+    extends:
+      service: base
+    build:
+      dockerfile: ./utilities/testrunners/php84/Dockerfile

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
 ## Requirements
-Smarty can be run with PHP 7.1 to PHP 8.3.
+Smarty can be run with PHP 7.1 to PHP 8.4.
 
 ## Installation
 Smarty can be installed with [Composer](https://getcomposer.org/).

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -1036,11 +1036,11 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * Get unique template id
      *
-     * @param string                    $template_name
-     * @param null|mixed                $cache_id
-     * @param null|mixed                $compile_id
-     * @param null                      $caching
-     * @param \Smarty_Internal_Template $template
+     * @param string                         $template_name
+     * @param null|mixed                     $cache_id
+     * @param null|mixed                     $compile_id
+     * @param null                           $caching
+     * @param \Smarty_Internal_Template|null $template
      *
      * @return string
      * @throws \SmartyException
@@ -1050,7 +1050,7 @@ class Smarty extends Smarty_Internal_TemplateBase
         $cache_id = null,
         $compile_id = null,
         $caching = null,
-        Smarty_Internal_Template $template = null
+        ?Smarty_Internal_Template $template = null
     ) {
         $template_name = (strpos($template_name, ':') === false) ? "{$this->default_resource_type}:{$template_name}" :
             $template_name;

--- a/libs/sysplugins/smarty_cacheresource.php
+++ b/libs/sysplugins/smarty_cacheresource.php
@@ -44,15 +44,15 @@ abstract class Smarty_CacheResource
     /**
      * Read the cached template and process header
      *
-     * @param Smarty_Internal_Template $_template template object
-     * @param Smarty_Template_Cached   $cached    cached object
-     * @param boolean                  $update    flag if called because cache update
+     * @param Smarty_Internal_Template    $_template template object
+     * @param Smarty_Template_Cached|null $cached    cached object
+     * @param boolean                     $update    flag if called because cache update
      *
      * @return boolean true or false if the cached content does not exist
      */
     abstract public function process(
         Smarty_Internal_Template $_template,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     );
 

--- a/libs/sysplugins/smarty_cacheresource_custom.php
+++ b/libs/sysplugins/smarty_cacheresource_custom.php
@@ -124,15 +124,15 @@ abstract class Smarty_CacheResource_Custom extends Smarty_CacheResource
     /**
      * Read the cached template and process the header
      *
-     * @param \Smarty_Internal_Template $_smarty_tpl do not change variable name, is used by compiled template
-     * @param Smarty_Template_Cached    $cached      cached object
-     * @param boolean                   $update      flag if called because cache update
+     * @param \Smarty_Internal_Template   $_smarty_tpl do not change variable name, is used by compiled template
+     * @param Smarty_Template_Cached|null $cached      cached object
+     * @param boolean                     $update      flag if called because cache update
      *
      * @return boolean                 true or false if the cached content does not exist
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         if (!$cached) {

--- a/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
+++ b/libs/sysplugins/smarty_cacheresource_keyvaluestore.php
@@ -88,15 +88,15 @@ abstract class Smarty_CacheResource_KeyValueStore extends Smarty_CacheResource
     /**
      * Read the cached template and process the header
      *
-     * @param \Smarty_Internal_Template $_smarty_tpl do not change variable name, is used by compiled template
-     * @param Smarty_Template_Cached    $cached      cached object
-     * @param boolean                   $update      flag if called because cache update
+     * @param \Smarty_Internal_Template   $_smarty_tpl do not change variable name, is used by compiled template
+     * @param Smarty_Template_Cached|null $cached      cached object
+     * @param boolean                     $update      flag if called because cache update
      *
      * @return boolean                 true or false if the cached content does not exist
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         if (!$cached) {

--- a/libs/sysplugins/smarty_internal_cacheresource_file.php
+++ b/libs/sysplugins/smarty_internal_cacheresource_file.php
@@ -88,15 +88,15 @@ class Smarty_Internal_CacheResource_File extends Smarty_CacheResource
     /**
      * Read the cached template and process its header
      *
-     * @param \Smarty_Internal_Template $_smarty_tpl do not change variable name, is used by compiled template
-     * @param Smarty_Template_Cached    $cached      cached object
-     * @param bool                      $update      flag if called because cache update
+     * @param \Smarty_Internal_Template   $_smarty_tpl do not change variable name, is used by compiled template
+     * @param Smarty_Template_Cached|null $cached      cached object
+     * @param bool                        $update      flag if called because cache update
      *
      * @return boolean true or false if the cached content does not exist
      */
     public function process(
         Smarty_Internal_Template $_smarty_tpl,
-        Smarty_Template_Cached $cached = null,
+        ?Smarty_Template_Cached $cached = null,
         $update = false
     ) {
         $_smarty_tpl->cached->valid = false;

--- a/libs/sysplugins/smarty_internal_data.php
+++ b/libs/sysplugins/smarty_internal_data.php
@@ -190,7 +190,7 @@ abstract class Smarty_Internal_Data
      *
      * @return mixed variable value or or array of variables
      */
-    public function getTemplateVars($varName = null, Smarty_Internal_Data $_ptr = null, $searchParents = true)
+    public function getTemplateVars($varName = null, ?Smarty_Internal_Data $_ptr = null, $searchParents = true)
     {
         return $this->ext->getTemplateVars->getTemplateVars($this, $varName, $_ptr, $searchParents);
     }
@@ -200,7 +200,7 @@ abstract class Smarty_Internal_Data
      *
      * @param \Smarty_Internal_Data|null $data
      */
-    public function _mergeVars(Smarty_Internal_Data $data = null)
+    public function _mergeVars(?Smarty_Internal_Data $data = null)
     {
         if (isset($data)) {
             if (!empty($this->tpl_vars)) {

--- a/libs/sysplugins/smarty_internal_method_createdata.php
+++ b/libs/sysplugins/smarty_internal_method_createdata.php
@@ -24,14 +24,14 @@ class Smarty_Internal_Method_CreateData
      * @api  Smarty::createData()
      * @link https://www.smarty.net/docs/en/api.create.data.tpl
      *
-     * @param \Smarty_Internal_TemplateBase|\Smarty_Internal_Template|\Smarty      $obj
-     * @param \Smarty_Internal_Template|\Smarty_Internal_Data|\Smarty_Data|\Smarty $parent next higher level of Smarty
-     *                                                                                     variables
-     * @param string                                                               $name   optional data block name
+     * @param \Smarty_Internal_TemplateBase|\Smarty_Internal_Template|\Smarty           $obj
+     * @param \Smarty_Internal_Template|\Smarty_Internal_Data|\Smarty_Data|\Smarty|null $parent next higher level of Smarty
+     *                                                                                          variables
+     * @param string                                                                    $name   optional data block name
      *
      * @return \Smarty_Data data object
      */
-    public function createData(Smarty_Internal_TemplateBase $obj, Smarty_Internal_Data $parent = null, $name = null)
+    public function createData(Smarty_Internal_TemplateBase $obj, ?Smarty_Internal_Data $parent = null, $name = null)
     {
         /* @var Smarty $smarty */
         $smarty = $obj->_getSmartyObj();

--- a/libs/sysplugins/smarty_internal_method_gettemplatevars.php
+++ b/libs/sysplugins/smarty_internal_method_gettemplatevars.php
@@ -24,17 +24,17 @@ class Smarty_Internal_Method_GetTemplateVars
      * @api  Smarty::getTemplateVars()
      * @link https://www.smarty.net/docs/en/api.get.template.vars.tpl
      *
-     * @param \Smarty_Internal_Data|\Smarty_Internal_Template|\Smarty $data
-     * @param string                                                  $varName       variable name or null
-     * @param \Smarty_Internal_Data|\Smarty_Internal_Template|\Smarty $_ptr          optional pointer to data object
-     * @param bool                                                    $searchParents include parent templates?
+     * @param \Smarty_Internal_Data|\Smarty_Internal_Template|\Smarty      $data
+     * @param string                                                       $varName       variable name or null
+     * @param \Smarty_Internal_Data|\Smarty_Internal_Template|\Smarty|null $_ptr          optional pointer to data object
+     * @param bool                                                         $searchParents include parent templates?
      *
      * @return mixed variable value or or array of variables
      */
     public function getTemplateVars(
         Smarty_Internal_Data $data,
         $varName = null,
-        Smarty_Internal_Data $_ptr = null,
+        ?Smarty_Internal_Data $_ptr = null,
         $searchParents = true
     ) {
         if (isset($varName)) {
@@ -87,7 +87,7 @@ class Smarty_Internal_Method_GetTemplateVars
     public function _getVariable(
         Smarty_Internal_Data $data,
         $varName,
-        Smarty_Internal_Data $_ptr = null,
+        ?Smarty_Internal_Data $_ptr = null,
         $searchParents = true,
         $errorEnable = true
     ) {

--- a/libs/sysplugins/smarty_internal_resource_eval.php
+++ b/libs/sysplugins/smarty_internal_resource_eval.php
@@ -22,11 +22,11 @@ class Smarty_Internal_Resource_Eval extends Smarty_Resource_Recompiled
      * populate Source Object with meta data from Resource
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->uid = $source->filepath = sha1($source->name);
         $source->timestamp = $source->exists = true;

--- a/libs/sysplugins/smarty_internal_resource_extends.php
+++ b/libs/sysplugins/smarty_internal_resource_extends.php
@@ -28,11 +28,11 @@ class Smarty_Internal_Resource_Extends extends Smarty_Resource
      * populate Source Object with meta data from Resource
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @throws SmartyException
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $uid = '';
         $sources = array();

--- a/libs/sysplugins/smarty_internal_resource_file.php
+++ b/libs/sysplugins/smarty_internal_resource_file.php
@@ -21,11 +21,11 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      * populate Source Object with meta data from Resource
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @throws \SmartyException
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = $this->buildFilepath($source, $_template);
         if ($source->filepath !== false) {
@@ -93,12 +93,12 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      * build template filepath by traversing the template_dir array
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @return string fully qualified filepath
      * @throws SmartyException
      */
-    protected function buildFilepath(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    protected function buildFilepath(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $file = $source->name;
         // absolute file ?

--- a/libs/sysplugins/smarty_internal_resource_stream.php
+++ b/libs/sysplugins/smarty_internal_resource_stream.php
@@ -23,11 +23,11 @@ class Smarty_Internal_Resource_Stream extends Smarty_Resource_Recompiled
      * populate Source Object with meta data from Resource
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         if (strpos($source->resource, '://') !== false) {
             $source->filepath = $source->resource;

--- a/libs/sysplugins/smarty_internal_resource_string.php
+++ b/libs/sysplugins/smarty_internal_resource_string.php
@@ -22,11 +22,11 @@ class Smarty_Internal_Resource_String extends Smarty_Resource
      * populate Source Object with meta data from Resource
      *
      * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Internal_Template|null $_template template object
      *
      * @return void
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->uid = $source->filepath = sha1($source->name . $source->smarty->_joined_template_dir);
         $source->timestamp = $source->exists = true;

--- a/libs/sysplugins/smarty_internal_runtime_codeframe.php
+++ b/libs/sysplugins/smarty_internal_runtime_codeframe.php
@@ -17,11 +17,11 @@ class Smarty_Internal_Runtime_CodeFrame
     /**
      * Create code frame for compiled and cached templates
      *
-     * @param Smarty_Internal_Template              $_template
-     * @param string                                $content   optional template content
-     * @param string                                $functions compiled template function and block code
-     * @param bool                                  $cache     flag for cache file
-     * @param \Smarty_Internal_TemplateCompilerBase $compiler
+     * @param Smarty_Internal_Template                   $_template
+     * @param string                                     $content   optional template content
+     * @param string                                     $functions compiled template function and block code
+     * @param bool                                       $cache     flag for cache file
+     * @param \Smarty_Internal_TemplateCompilerBase|null $compiler
      *
      * @return string
      */
@@ -30,7 +30,7 @@ class Smarty_Internal_Runtime_CodeFrame
         $content = '',
         $functions = '',
         $cache = false,
-        Smarty_Internal_TemplateCompilerBase $compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $compiler = null
     ) {
         // build property code
         $properties[ 'version' ] = Smarty::SMARTY_VERSION;

--- a/libs/sysplugins/smarty_internal_runtime_inheritance.php
+++ b/libs/sysplugins/smarty_internal_runtime_inheritance.php
@@ -168,7 +168,7 @@ class Smarty_Internal_Runtime_Inheritance
     public function process(
         Smarty_Internal_Template $tpl,
         Smarty_Internal_Block $block,
-        Smarty_Internal_Block $parent = null
+        ?Smarty_Internal_Block $parent = null
     ) {
         if ($block->hide && !isset($block->child)) {
             return;

--- a/libs/sysplugins/smarty_internal_template.php
+++ b/libs/sysplugins/smarty_internal_template.php
@@ -149,7 +149,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
     public function __construct(
         $template_resource,
         Smarty $smarty,
-        Smarty_Internal_Data $_parent = null,
+        ?Smarty_Internal_Data $_parent = null,
         $_cache_id = null,
         $_compile_id = null,
         $_caching = null,

--- a/libs/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/libs/sysplugins/smarty_internal_templatecompilerbase.php
@@ -386,7 +386,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
     public function compileTemplate(
         Smarty_Internal_Template $template,
         $nocache = null,
-        Smarty_Internal_TemplateCompilerBase $parent_compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $parent_compiler = null
     ) {
         // get code frame of compiled template
         $_compiled_code = $template->smarty->ext->_codeFrame->create(
@@ -407,9 +407,9 @@ abstract class Smarty_Internal_TemplateCompilerBase
     /**
      * Compile template source and run optional post filter
      *
-     * @param \Smarty_Internal_Template             $template
-     * @param null|bool                             $nocache flag if template must be compiled in nocache mode
-     * @param \Smarty_Internal_TemplateCompilerBase $parent_compiler
+     * @param \Smarty_Internal_Template                  $template
+     * @param null|bool                                  $nocache flag if template must be compiled in nocache mode
+     * @param \Smarty_Internal_TemplateCompilerBase|null $parent_compiler
      *
      * @return string
      * @throws \Exception
@@ -417,7 +417,7 @@ abstract class Smarty_Internal_TemplateCompilerBase
     public function compileTemplateSource(
         Smarty_Internal_Template $template,
         $nocache = null,
-        Smarty_Internal_TemplateCompilerBase $parent_compiler = null
+        ?Smarty_Internal_TemplateCompilerBase $parent_compiler = null
     ) {
         try {
             // save template object in compiler class

--- a/libs/sysplugins/smarty_resource.php
+++ b/libs/sysplugins/smarty_resource.php
@@ -165,16 +165,16 @@ abstract class Smarty_Resource
      * wrapper for backward compatibility to versions < 3.1.22
      * Either [$_template] or [$smarty, $template_resource] must be specified
      *
-     * @param Smarty_Internal_Template $_template         template object
-     * @param Smarty                   $smarty            smarty object
-     * @param string                   $template_resource resource identifier
+     * @param Smarty_Internal_Template|null $_template         template object
+     * @param Smarty|null                   $smarty            smarty object
+     * @param string                        $template_resource resource identifier
      *
      * @return \Smarty_Template_Source Source Object
      * @throws \SmartyException
      */
     public static function source(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         return Smarty_Template_Source::load($_template, $smarty, $template_resource);
@@ -193,10 +193,10 @@ abstract class Smarty_Resource
     /**
      * populate Source Object with meta data from Resource
      *
-     * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Template_Source        $source    source object
+     * @param Smarty_Internal_Template|null $_template template object
      */
-    abstract public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null);
+    abstract public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null);
 
     /**
      * populate Source Object with timestamp and exists from Resource

--- a/libs/sysplugins/smarty_resource_custom.php
+++ b/libs/sysplugins/smarty_resource_custom.php
@@ -42,10 +42,10 @@ abstract class Smarty_Resource_Custom extends Smarty_Resource
     /**
      * populate Source Object with meta data from Resource
      *
-     * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Template_Source        $source    source object
+     * @param Smarty_Internal_Template|null $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = $source->type . ':' . $this->generateSafeName($source->name);
         $source->uid = sha1($source->type . ':' . $source->name);

--- a/libs/sysplugins/smarty_template_config.php
+++ b/libs/sysplugins/smarty_template_config.php
@@ -63,16 +63,16 @@ class Smarty_Template_Config extends Smarty_Template_Source
      * initialize Source Object for given resource
      * Either [$_template] or [$smarty, $template_resource] must be specified
      *
-     * @param Smarty_Internal_Template $_template         template object
-     * @param Smarty                   $smarty            smarty object
-     * @param string                   $template_resource resource identifier
+     * @param Smarty_Internal_Template|null $_template         template object
+     * @param Smarty|null                   $smarty            smarty object
+     * @param string                        $template_resource resource identifier
      *
      * @return Smarty_Template_Config Source Object
      * @throws SmartyException
      */
     public static function load(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         static $_incompatible_resources = array('extends' => true, 'php' => true);

--- a/libs/sysplugins/smarty_template_source.php
+++ b/libs/sysplugins/smarty_template_source.php
@@ -148,16 +148,16 @@ class Smarty_Template_Source
      * initialize Source Object for given resource
      * Either [$_template] or [$smarty, $template_resource] must be specified
      *
-     * @param Smarty_Internal_Template $_template         template object
-     * @param Smarty                   $smarty            smarty object
-     * @param string                   $template_resource resource identifier
+     * @param Smarty_Internal_Template|null $_template         template object
+     * @param Smarty|null                   $smarty            smarty object
+     * @param string                        $template_resource resource identifier
      *
      * @return Smarty_Template_Source Source Object
      * @throws SmartyException
      */
     public static function load(
-        Smarty_Internal_Template $_template = null,
-        Smarty $smarty = null,
+        ?Smarty_Internal_Template $_template = null,
+        ?Smarty $smarty = null,
         $template_resource = null
     ) {
         if ($_template) {

--- a/libs/sysplugins/smartycompilerexception.php
+++ b/libs/sysplugins/smartycompilerexception.php
@@ -21,7 +21,7 @@ class SmartyCompilerException extends SmartyException
         int $code = 0,
         ?string $filename = null,
         ?int $line = null,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/run-tests-for-all-php-versions.sh
+++ b/run-tests-for-all-php-versions.sh
@@ -14,4 +14,5 @@ $COMPOSE_CMD run --rm php74 ./run-tests.sh $@ && \
 $COMPOSE_CMD run --rm php80 ./run-tests.sh $@ && \
 $COMPOSE_CMD run --rm php81 ./run-tests.sh $@ && \
 $COMPOSE_CMD run --rm php82 ./run-tests.sh $@ && \
-$COMPOSE_CMD run --rm php83 ./run-tests.sh $@
+$COMPOSE_CMD run --rm php83 ./run-tests.sh $@ && \
+$COMPOSE_CMD run --rm php84 ./run-tests.sh $@

--- a/tests/PHPUnit_Smarty.php
+++ b/tests/PHPUnit_Smarty.php
@@ -68,7 +68,7 @@ class PHPUnit_Smarty extends PHPUnit\Framework\TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        error_reporting(E_ALL & ~E_STRICT);
+        error_reporting(E_ALL);
         self::$init = true;
         self::$pluginsdir =self::getSmartyPluginsDir();
     }

--- a/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/PHPunitplugins/resource.filetest.php
@@ -5,10 +5,10 @@ class Smarty_Resource_Filetest extends Smarty_Internal_Resource_File
     /**
      * populate Source Object with meta data from Resource
      *
-     * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Template_Source        $source    source object
+     * @param Smarty_Internal_Template|null $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         parent::populate($source, $_template);
         if ($source->exists) {

--- a/tests/UnitTests/ConfigFileTests/file/PHPunitplugins/resource.db4.php
+++ b/tests/UnitTests/ConfigFileTests/file/PHPunitplugins/resource.db4.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db4 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db4:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
+++ b/tests/UnitTests/ResourceTests/Custom/Ambiguous/PHPunitplugins/resource.ambiguous.php
@@ -38,10 +38,10 @@ class Smarty_Resource_Ambiguous extends Smarty_Internal_Resource_File
     /**
      * populate Source Object with meta data from Resource
      *
-     * @param Smarty_Template_Source   $source    source object
-     * @param Smarty_Internal_Template $_template template object
+     * @param Smarty_Template_Source        $source    source object
+     * @param Smarty_Internal_Template|null $_template template object
      */
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $segment = '';
         if ($this->segment) {

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db extends Smarty_Resource_Recompiled {
 
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null) {
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null) {
         $source->filepath = 'db:';
         $source->uid = sha1($source->resource);
         $source->timestamp = 1000000000;

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db2.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db2 extends Smarty_Resource_Recompiled
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db2:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db3.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db3 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db3:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
+++ b/tests/UnitTests/ResourceTests/ResourcePlugins/PHPunitplugins/resource.db4.php
@@ -12,7 +12,7 @@
 
 class Smarty_Resource_Db4 extends Smarty_Resource
 {
-    public function populate(Smarty_Template_Source $source, Smarty_Internal_Template $_template = null)
+    public function populate(Smarty_Template_Source $source, ?Smarty_Internal_Template $_template = null)
     {
         $source->filepath = 'db4:';
         $source->uid = sha1($source->resource);

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -152,10 +152,10 @@ class SecurityTest extends PHPUnit_Smarty
  */
     public function testAllowedModifier1()
     {
-        error_reporting(E_ALL  & E_STRICT);
+        error_reporting(E_ALL);
         $this->smarty->security_policy->allowed_modifiers = array('capitalize');
         $this->assertEquals("Hello World", $this->smarty->fetch('string:{"hello world"|capitalize}'));
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
     }
 
     public function testAllowedModifier2()

--- a/utilities/testrunners/php84/Dockerfile
+++ b/utilities/testrunners/php84/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.4-rc-cli-bullseye
+
+## Basic utilities
+RUN apt-get update -yqq && apt-get install -y curl apt-utils git zip unzip
+
+## Composer
+COPY ./utilities/testrunners/shared/install-composer.sh /root/install-composer.sh
+WORKDIR /root
+RUN sh ./install-composer.sh
+RUN mv ./composer.phar /usr/local/bin/composer


### PR DESCRIPTION
This PR is mostly a backport of https://github.com/smarty-php/smarty/pull/1043 for version 4

This pull request updates the code base to support the deprecations introduced in PHP 8.4. It should be backwards compatible.

Updated the function signatures that had implicit null assignment to typed parameters.
Added PHP 8.4 to the 'run tests'-shell script.
Bumped the PHP version in the README.md