### PR TITLE
Support unnamed function arguments to compiler plugins in Smarty 5

### DIFF
--- a/src/Compile/Base.php
+++ b/src/Compile/Base.php
@@ -70,6 +70,17 @@ abstract class Base implements CompilerInterface {
 	}
 
 	/**
+	 * Returns attribute index for unnamed ("shorthand") attribute, or null if not allowed.
+	 *
+	 * @param int $key
+	 *
+	 * @return string|int|null
+	 */
+	protected function getShorthandOrder(int $key) {
+	    return $this->shorttag_order[$key] ?? null;
+	}
+
+	/**
 	 * This function checks if the attributes passed are valid
 	 * The attributes passed for the tag to compile are checked against the list of required and
 	 * optional attributes. Required attributes must be present. Optional attributes are check against
@@ -91,8 +102,8 @@ abstract class Base implements CompilerInterface {
 				if (isset($options[trim($mixed, '\'"')])) {
 					$_indexed_attr[trim($mixed, '\'"')] = true;
 					// shorthand attribute ?
-				} elseif (isset($this->shorttag_order[$key])) {
-					$_indexed_attr[$this->shorttag_order[$key]] = $mixed;
+				} elseif (!is_null($this->getShorthandOrder($key))) {
+					$_indexed_attr[$this->getShorthandOrder($key)] = $mixed;
 				} else {
 					// too many shorthands
 					$compiler->trigger_template_error('too many shorthand attributes', null, true);

--- a/src/Compile/Tag/BCPluginWrapper.php
+++ b/src/Compile/Tag/BCPluginWrapper.php
@@ -21,6 +21,20 @@ class BCPluginWrapper extends Base {
 		$this->cacheable = $cacheable;
 	}
 
+        /**
+         * Returns attribute index for unnamed ("shorthand") attribute, or null if not allowed.
+         *
+         * For compiler plugins, we allow arbitrarily many unnamed attributes,
+         * and just make them accessible in the order they are set.
+         *
+         * @param int $key
+         *
+         * @return int
+         */
+        protected function getShorthandOrder(int $key): int {
+            return $key;
+        }
+
 	/**
 	 * @inheritDoc
 	 */

--- a/tests/UnitTests/SmartyMethodsTests/RegisterCompiler/RegisterCompilerFunctionTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/RegisterCompiler/RegisterCompilerFunctionTest.php
@@ -34,7 +34,7 @@ class RegisterCompilerFunctionTest extends PHPUnit_Smarty
     {
         $this->smarty->registerPlugin(Smarty::PLUGIN_COMPILER, 'testcompilerfunction', 'mycompilerfunction');
         $this->assertEquals('mycompilerfunction', $this->smarty->getRegisteredPlugin('compiler', 'testcompilerfunction')[0]);
-        $this->assertEquals('hello world 1', $this->smarty->fetch('eval:{testcompilerfunction var=1}'));
+        $this->assertEquals('hello world 1 2', $this->smarty->fetch('eval:{testcompilerfunction 1 var=2}'));
     }
 
     /**
@@ -99,7 +99,7 @@ class RegisterCompilerFunctionTest extends PHPUnit_Smarty
 
 function mycompilerfunction($params, $smarty)
 {
-    return "<?php echo 'hello world {$params['var']}';?>";
+    return "<?php echo 'hello world {$params[0]} {$params['var']}';?>";
 }
 
 function mycompilerfunctionopen($params, $smarty)


### PR DESCRIPTION
Fixes the regression in Smarty 5 where a compiler function using unnamed arguments threw a "Too many shorthand 
attributes" error, and adds unit test coverage.

Fixes #1085 