### PR TITLE
Update PHP8.3 to 8.4 in getting-started.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
 ## Requirements
-Smarty can be run with PHP 7.2 to PHP 8.3.
+Smarty can be run with PHP 7.2 to PHP 8.4.
 
 ## Installation
 Smarty can be installed with [Composer](https://getcomposer.org/).


### PR DESCRIPTION
The supported PHP version on the "getting-started" page of the documentation was up to 8.3, so I fixed it to 8.4.