### PR TITLE
add missing closing tr tag

### DIFF
--- a/libs/debug.tpl
+++ b/libs/debug.tpl
@@ -144,6 +144,7 @@
                         {$vars['attributes']|debug_print_var nofilter}
                     {/if}
                 </td>
+            </tr>
          {/foreach}
     </table>
 


### PR DESCRIPTION
Add missing end tag for 'assigned template variables' section.
Backport of d6153d4