### PR TITLE
Improve `{*}` comment parsing for better consistency with IDEs and old projects

### DIFF
--- a/src/Lexer/TemplateLexer.php
+++ b/src/Lexer/TemplateLexer.php
@@ -381,7 +381,7 @@ class TemplateLexer
     {
 
        $to = $this->dataLength;
-       preg_match("/[*]{$this->compiler->getRdelPreg()}[\n]?/",$this->data,$match,PREG_OFFSET_CAPTURE,$this->counter);
+       preg_match("/[*]{$this->compiler->getRdelPreg()}[\n]?/",$this->data,$match,PREG_OFFSET_CAPTURE,$this->counter+2);
         if (isset($match[0][1])) {
             $to = $match[0][1] + strlen($match[0][0]);
         } else {

--- a/tests/UnitTests/TemplateSource/Comments/CommentsTest.php
+++ b/tests/UnitTests/TemplateSource/Comments/CommentsTest.php
@@ -69,6 +69,7 @@ class CommentsTest extends PHPUnit_Smarty
                      array("=\na\n{* comment 1 *}\n {* comment 2 *}\n{* comment 3 *}\nb\n=", "=\na\n b\n=", 'T12', $i++),
                      array("=\na\n{* comment 1 *}\n{* comment 2 *} \n{* comment 3 *}\nb\n=", "=\na\n \nb\n=", 'T13', $i++),
                      array("=\na\n{* comment 1 *}\n {* comment 2 *} \n{* comment 3 *}\nb\n=", "=\na\n  \nb\n=", 'T14', $i++),
+                     array("K{*} comment 1 *}L{*} comment 2 {*}", "KL", 'T15', $i++),
         );
     }
 


### PR DESCRIPTION
This PR adjusts `{*}` comment parsing behavior to resolve inconsistencies with IDE syntax highlighting (e.g., PhpStorm, VS Code) and to better support projects upgrading from Smarty v2.

**Why:**
- In legacy Smarty v2, `{*}` comments required `*}` to close, which aligns with modern IDE behaviors.
- Current behavior treats `{*}` as both the start and end of a comment, which causes confusion when using IDEs or updating old templates.

### Behavior Before and After
For the following code:
``` smarty
{*} comment 1 {*}
```
**Before:**
Outputs: `comment 1`

**After:**
Outputs: _(nothing, comment is ignored as expected)_

This fixes parsing inconsistencies, aligns with IDE syntax highlighting, and retains expected behavior for old templates written in Smarty v2.

### Screenshots
Screenshots of IDE comment highlighting
#### PhpStorm
![002n](https://github.com/user-attachments/assets/40a7b7d7-e832-4867-a60e-668c864a02b8)

#### VS Code
![002o](https://github.com/user-attachments/assets/af9496d4-a5bf-4d97-b0db-e015d50eb8c5)

