### PR TITLE
Bugfix/bcpluginsadapter support modifiercompiler

### DIFF
--- a/src/Extension/BCPluginsAdapter.php
+++ b/src/Extension/BCPluginsAdapter.php
@@ -176,7 +176,7 @@ class BCPluginsAdapter extends Base {
 		    'prefilter',
 		    'postfilter',
 		    'outputfilter',
-			'modifiercompiler',
+		    'modifiercompiler',
 		] as $type) {
 			foreach (glob($path  . $type . '.?*.php') as $filename) {
 				$pluginName = $this->getPluginNameFromFilename($filename);

--- a/src/Extension/BCPluginsAdapter.php
+++ b/src/Extension/BCPluginsAdapter.php
@@ -168,7 +168,6 @@ class BCPluginsAdapter extends Base {
 	}
 
 	public function loadPluginsFromDir(string $path) {
-
 		foreach([
 			'function',
 			'modifier',
@@ -177,6 +176,7 @@ class BCPluginsAdapter extends Base {
 		    'prefilter',
 		    'postfilter',
 		    'outputfilter',
+			'modifiercompiler',
 		] as $type) {
 			foreach (glob($path  . $type . '.?*.php') as $filename) {
 				$pluginName = $this->getPluginNameFromFilename($filename);


### PR DESCRIPTION
The BC plugins adapter is missing support for modifiercompiler functions, this merge request fixes this.