### PR TITLE
Resolved the "Passing null to parameter" error when using the count_* modifiers

### DIFF
--- a/src/Compile/Modifier/CountCharactersModifierCompiler.php
+++ b/src/Compile/Modifier/CountCharactersModifierCompiler.php
@@ -13,7 +13,7 @@ class CountCharactersModifierCompiler extends Base {
 
 	public function compile($params, \Smarty\Compiler\Template $compiler) {
 		if (!isset($params[ 1 ]) || $params[ 1 ] !== 'true') {
-			return 'preg_match_all(\'/[^\s]/' . \Smarty\Smarty::$_UTF8_MODIFIER . '\',' . $params[ 0 ] . ', $tmp)';
+			return 'preg_match_all(\'/[^\s]/' . \Smarty\Smarty::$_UTF8_MODIFIER . '\', (string)' . $params[ 0 ] . ', $tmp)';
 		}
 		return 'mb_strlen((string) ' . $params[ 0 ] . ', \'' . addslashes(\Smarty\Smarty::$_CHARSET) . '\')';
 	}

--- a/src/Compile/Modifier/CountParagraphsModifierCompiler.php
+++ b/src/Compile/Modifier/CountParagraphsModifierCompiler.php
@@ -13,7 +13,7 @@ class CountParagraphsModifierCompiler extends Base {
 
 	public function compile($params, \Smarty\Compiler\Template $compiler) {
 		// count \r or \n characters
-		return '(preg_match_all(\'#[\r\n]+#\', ' . $params[ 0 ] . ', $tmp)+1)';
+		return '(preg_match_all(\'#[\r\n]+#\', (string)' . $params[ 0 ] . ', $tmp)+1)';
 	}
 
 }

--- a/src/Compile/Modifier/CountSentencesModifierCompiler.php
+++ b/src/Compile/Modifier/CountSentencesModifierCompiler.php
@@ -13,7 +13,7 @@ class CountSentencesModifierCompiler extends Base {
 
 	public function compile($params, \Smarty\Compiler\Template $compiler) {
 		// find periods, question marks, exclamation marks with a word before but not after.
-		return 'preg_match_all("#\w[\.\?\!](\W|$)#S' . \Smarty\Smarty::$_UTF8_MODIFIER . '", ' . $params[ 0 ] . ', $tmp)';
+		return 'preg_match_all("#\w[\.\?\!](\W|$)#S' . \Smarty\Smarty::$_UTF8_MODIFIER . '", (string)' . $params[ 0 ] . ', $tmp)';
 	}
 
 }

--- a/src/Compile/Modifier/CountWordsModifierCompiler.php
+++ b/src/Compile/Modifier/CountWordsModifierCompiler.php
@@ -14,7 +14,7 @@ class CountWordsModifierCompiler extends Base {
 	public function compile($params, \Smarty\Compiler\Template $compiler) {
 		// expression taken from http://de.php.net/manual/en/function.str-word-count.php#85592
 		return 'preg_match_all(\'/\p{L}[\p{L}\p{Mn}\p{Pd}\\\'\x{2019}]*/' . \Smarty\Smarty::$_UTF8_MODIFIER . '\', ' .
-			$params[ 0 ] . ', $tmp)';
+			'(string)' . $params[ 0 ] . ', $tmp)';
 	}
 
 }

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountCharactersTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountCharactersTest.php
@@ -48,4 +48,12 @@ class PluginModifierCountCharactersTest extends PHPUnit_Smarty
         $this->assertEquals(str_replace("\r", '', $result), $this->smarty->fetch($tpl));
     }
 
+    public function testNull()
+    {
+        $tpl = $this->smarty->createTemplate('string:{null|count_characters}');
+        $this->assertEquals("0", $this->smarty->fetch($tpl));
+        $tpl = $this->smarty->createTemplate('string:{null|count_characters:true}');
+        $this->assertEquals("0", $this->smarty->fetch($tpl));
+    }
+
 }

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountParagraphsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountParagraphsTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Smarty PHPunit tests of modifier
+ */
+
+/**
+ * class for modifier tests
+ *
+ * 
+ * 
+ * 
+ */
+class PluginModifierCountParagraphsTest extends PHPUnit_Smarty
+{
+    public function setUp(): void
+    {
+        $this->setUpSmarty(__DIR__);
+    }
+
+    public function testInit()
+    {
+        $this->cleanDirs();
+    }
+
+    public function testDefault()
+    {
+    $tpl = $this->smarty->createTemplate('string:{"One paragraph only."|count_paragraphs}');
+    $this->assertEquals("1", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"First line.\nSecond line."|count_paragraphs}');
+    $this->assertEquals("2", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"Paragraph1\nParagraph2\nParagraph3"|count_paragraphs}');
+    $this->assertEquals("3", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"Paragraph1\n\nParagraph2"|count_paragraphs}');
+    $this->assertEquals("2", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"Paragraph1\r\nParagraph2\nParagraph3\rParagraph4"|count_paragraphs}');
+    $this->assertEquals("4", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"End with newline\n"|count_paragraphs}');
+    $this->assertEquals("2", $this->smarty->fetch($tpl));
+    $tpl = $this->smarty->createTemplate('string:{"\nStart with newline"|count_paragraphs}');
+    $this->assertEquals("2", $this->smarty->fetch($tpl));
+    }
+
+    public function testNull()
+    {
+        $tpl = $this->smarty->createTemplate('string:{null|count_paragraphs}');
+        $this->assertEquals("1", $this->smarty->fetch($tpl));
+    }
+}

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountSentencesTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountSentencesTest.php
@@ -48,4 +48,10 @@ class PluginModifierCountSentencesTest extends PHPUnit_Smarty
         $tpl = $this->smarty->createTemplate('string:{"hello world.ärong"|count_sentences}');
         $this->assertEquals("0", $this->smarty->fetch($tpl));
     }
+
+    public function testNull()
+    {
+        $tpl = $this->smarty->createTemplate('string:{null|count_sentences}');
+        $this->assertEquals("0", $this->smarty->fetch($tpl));
+    }
 }

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountWordsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierCountWordsTest.php
@@ -41,4 +41,10 @@ class PluginModifierCountWordsTest extends PHPUnit_Smarty
         $this->assertEquals(str_replace("\r", '', $result), $this->smarty->fetch($tpl));
     }
 
+    public function testNull()
+    {
+        $result = "0";
+        $tpl = $this->smarty->createTemplate('string:{null|count_words}');
+        $this->assertEquals(str_replace("\r", '', $result), $this->smarty->fetch($tpl));
+    }
 }


### PR DESCRIPTION
Hi, there!

This PR fixes #1108 

I have fixed the code that could cause the "Passing null to parameter" error when using the count_* modifiers.
I also, added test code for the count_paragraphs function. This test did not exist before.
I would appreciate it if you could confirm this.

Thank you!