### PR TITLE
Fix compileAll() behavior.

### DIFF
--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -1487,7 +1487,7 @@ class Smarty extends \Smarty\TemplateBase {
 				//
 				$_smarty->force_compile = $force_compile;
 				try {
-					$_tpl = $this->doCreateTemplate($_file);
+					$_tpl = $_smarty->doCreateTemplate($_file);
 					$_tpl->caching = self::CACHING_OFF;
 					$_tpl->setSource(
 						$isConfig ? \Smarty\Template\Config::load($_tpl) : \Smarty\Template\Source::load($_tpl)
@@ -1507,7 +1507,7 @@ class Smarty extends \Smarty\TemplateBase {
 				}
 				// free memory
 				unset($_tpl);
-				if ($max_errors !== null && $_error_count === $max_errors) {
+				if ($max_errors !== null && $_error_count > $max_errors) {
 					echo "\ntoo many errors\n";
 					exit(1);
 				}


### PR DESCRIPTION
`compileAll()` has two issues that get fixed with this commit:

1. `$force_compile` is ignored since it is applied to a cloned instance of Smarty that then is not used.
2. The `$max_errors` variable behaves strange as the function stops executing as soon $max_errors is reached. However, the name suggests that `$max_errors` is the maximum number of acceptable errors (defaults to `null` meaning unlimited). When called with `$max_errors = 0`, the function compiles only the first template and then stops with "too many errors" and a total error count of zero.