### PR TITLE
Unify {function} and {call} example and fix link.

### DIFF
--- a/docs/designers/language-builtin-functions/language-function-call.md
+++ b/docs/designers/language-builtin-functions/language-function-call.md
@@ -9,7 +9,7 @@ function.
 > Template functions are defined global. Since the Smarty compiler is a
 > single-pass compiler, The `{call}` tag must
 > be used to call a template function defined externally from the given
-> template. Otherwise you can directly use the function as
+> template. Otherwise, you can directly use the function as
 > `{funcname ...}` in the template.
 
 -   The `{call}` tag must have the `name` attribute which contains the
@@ -36,42 +36,44 @@ function.
 ## Examples
 
 ```smarty
-    {* define the function *}
-    {function name=menu level=0}
-      <ul class="level{$level}">
-      {foreach $data as $entry}
-        {if is_array($entry)}
-          <li>{$entry@key}</li>
-          {call name=menu data=$entry level=$level+1}
-        {else}
-          <li>{$entry}</li>
-        {/if}
-      {/foreach}
-      </ul>
-    {/function}
+{* define the function *}
+{function name=menu level=0}
+{function menu level=0}          {* short-hand *}
+  <ul class="level{$level}">
+  {foreach $data as $entry}
+    {if is_array($entry)}
+      <li>{$entry@key}</li>
+      {call name=menu data=$entry level=$level+1}
+      {menu data=$entry level=$level+1}    {* short-hand *}
+    {else}
+      <li>{$entry}</li>
+    {/if}
+  {/foreach}
+  </ul>
+{/function}
 
-    {* create an array to demonstrate *}
-    {$menu = ['item1','item2','item3' => ['item3-1','item3-2','item3-3' =>
-    ['item3-3-1','item3-3-2']],'item4']}
+{* create an array to demonstrate *}
+{$menu = ['item1','item2','item3' => ['item3-1','item3-2','item3-3' =>
+['item3-3-1','item3-3-2']],'item4']}
 
-    {* run the array through the function *}
-    {call name=menu data=$menu}
-    {call menu data=$menu} {* short-hand *}
+{* run the array through the function *}
+{call name=menu data=$menu}
+{call menu data=$menu} {* short-hand *}
+{menu data=$menu} {* even shorter short-hand *}
 ```
-     
 
 Will generate the following output
 
 ```
-    * item1
-    * item2
-    * item3
-          o item3-1
-          o item3-2
-          o item3-3
-                + item3-3-1
-                + item3-3-2
-    * item4
+* item1
+* item2
+* item3
+      o item3-1
+      o item3-2
+      o item3-3
+            + item3-3-1
+            + item3-3-2
+* item4
 ```
 
 See also [`{function}`](./language-function-function.md).

--- a/docs/designers/language-builtin-functions/language-function-function.md
+++ b/docs/designers/language-builtin-functions/language-function-function.md
@@ -9,7 +9,7 @@ nested menus.
 > **Note**
 >
 > Template functions are defined global. Since the Smarty compiler is a
-> single-pass compiler, The [`{call}`](#language.function.call) tag must
+> single-pass compiler, The [`{call}`](./language-function-call.md) tag must
 > be used to call a template function defined externally from the given
 > template. Otherwise, you can directly use the function as
 > `{funcname ...}` in the template.
@@ -56,7 +56,8 @@ nested menus.
   {foreach $data as $entry}
     {if is_array($entry)}
       <li>{$entry@key}</li>
-      {menu data=$entry level=$level+1}
+      {call name=menu data=$entry level=$level+1}
+      {menu data=$entry level=$level+1}    {* short-hand *}
     {else}
       <li>{$entry}</li>
     {/if}
@@ -69,7 +70,9 @@ nested menus.
 ['item3-3-1','item3-3-2']],'item4']}
 
 {* run the array through the function *}
-{menu data=$menu}
+{call name=menu data=$menu}
+{call menu data=$menu} {* short-hand *}
+{menu data=$menu} {* even shorter short-hand *}
 ```
 
 Will generate the following output
@@ -85,5 +88,5 @@ Will generate the following output
             + item3-3-2
 * item4
 ```
-      
+
 See also [`{call}`](./language-function-call.md)


### PR DESCRIPTION
The documentation of the two tags already use the same example. However, there subtle differences. This PR extends both pages to contain the same information. The PR also fixes a broken link on the `{function}` page.