### PR TITLE
Fix documentation links.

### DIFF
--- a/docs/api/caching/multiple-caches-per-template.md
+++ b/docs/api/caching/multiple-caches-per-template.md
@@ -25,7 +25,7 @@ $smarty->display('index.tpl', $my_cache_id);
 
 
 Above, we are passing the variable `$my_cache_id` to
-[`display()`](#api.display) as the `$cache_id`. For each unique value of
+[`display()`](../../programmers/api-functions/api-display.md) as the `$cache_id`. For each unique value of
 `$my_cache_id`, a separate cache will be generated for `index.tpl`. In
 this example, `article_id` was passed in the URL and is used as the
 `$cache_id`.

--- a/docs/designers/language-builtin-functions/language-function-append.md
+++ b/docs/designers/language-builtin-functions/language-function-append.md
@@ -45,5 +45,5 @@ The above example will output:
 
       
 
-See also [`append()`](#api.append) and
-[`getTemplateVars()`](#api.get.template.vars).
+See also [`append()`](../../programmers/api-functions/api-append.md) and
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md).

--- a/docs/designers/language-builtin-functions/language-function-assign.md
+++ b/docs/designers/language-builtin-functions/language-function-assign.md
@@ -134,15 +134,15 @@ $smarty->assign('foo','Even smarter');
 echo $smarty->getTemplateVars('foo');
 ```
 
-The following functions can also *optionally* assign template variables: [`{capture}`](#language.function.capture),
-[`{include}`](#language.function.include),
-[`{counter}`](#language.function.counter),
-[`{cycle}`](#language.function.cycle),
-[`{eval}`](#language.function.eval),
-[`{fetch}`](#language.function.fetch),
-[`{math}`](#language.function.math) and
-[`{textformat}`](#language.function.textformat).
+The following functions can also *optionally* assign template variables: [`{capture}`](language-function-capture.md),
+[`{include}`](language-function-include.md),
+[`{counter}`](../language-custom-functions/language-function-counter.md),
+[`{cycle}`](../language-custom-functions/language-function-cycle.md),
+[`{eval}`](../language-custom-functions/language-function-eval.md),
+[`{fetch}`](../language-custom-functions/language-function-fetch.md),
+[`{math}`](../language-custom-functions/language-function-math.md) and
+[`{textformat}`](../language-custom-functions/language-function-textformat.md).
 
 See also [`{append}`](./language-function-append.md),
-[`assign()`](#api.assign) and
-[`getTemplateVars()`](#api.get.template.vars).
+[`assign()`](../../programmers/api-functions/api-assign.md) and
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md).

--- a/docs/designers/language-builtin-functions/language-function-config-load.md
+++ b/docs/designers/language-builtin-functions/language-function-config-load.md
@@ -1,7 +1,7 @@
 # {config_load}
 
 `{config_load}` is used for loading config
-[`#variables#`](#language.config.variables) from a [configuration file](#config.files) into the template.
+[`#variables#`](../language-variables/language-config-variables.md) from a [configuration file](../config-files.md) into the template.
 
 ## Attributes
 

--- a/docs/designers/language-builtin-functions/language-function-function.md
+++ b/docs/designers/language-builtin-functions/language-function-function.md
@@ -9,7 +9,7 @@ nested menus.
 > **Note**
 >
 > Template functions are defined global. Since the Smarty compiler is a
-> single-pass compiler, The [`{call}`](#language.function.call) tag must
+> single-pass compiler, The [`{call}`](language-function-call.md) tag must
 > be used to call a template function defined externally from the given
 > template. Otherwise, you can directly use the function as
 > `{funcname ...}` in the template.

--- a/docs/designers/language-modifiers/language-modifier-to-charset.md
+++ b/docs/designers/language-modifiers/language-modifier-to-charset.md
@@ -1,8 +1,8 @@
 # to_charset
 
 `to_charset` is used to transcode a string from the internal charset to
-a given charset. This is the exact opposite of the [from_charset
-modifier](#language.modifier.from_charset).
+a given charset. This is the exact opposite of the 
+[from_charset modifier](language-modifier-from-charset.md).
 
 ## Parameters
 
@@ -16,5 +16,5 @@ modifier](#language.modifier.from_charset).
 > modifier should only be used in cases where the application cannot
 > anticipate that a certain string is required in another encoding.
 
-See also [Configuring Smarty](../../api/configuring.md), [from_charset
-modifier](language-modifier-from-charset.md).
+See also [Configuring Smarty](../../api/configuring.md) and 
+[from_charset modifier](language-modifier-from-charset.md).

--- a/docs/programmers/api-functions/api-add-plugins-dir.md
+++ b/docs/programmers/api-functions/api-add-plugins-dir.md
@@ -37,6 +37,5 @@ plugins\_dir
 
        
 
-See also [`getPluginsDir()`](#api.get.plugins.dir),
-[`setPluginsDir()`](#api.set.plugins.dir) and
-[`$plugins_dir`](#variable.plugins.dir).
+See also [`getPluginsDir()`](../../programmers/api-functions/api-get-plugins-dir.md) and
+[`setPluginsDir()`](../../programmers/api-functions/api-set-plugins-dir.md)

--- a/docs/programmers/api-functions/api-append.md
+++ b/docs/programmers/api-functions/api-append.md
@@ -56,5 +56,5 @@ NOTE.PARAMETER.MERGE
 
        
 
-See also [`assign()`](#api.assign) and
-[`getTemplateVars()`](#api.get.template.vars)
+See also [`assign()`](../../programmers/api-functions/api-assign.md) and
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md)

--- a/docs/programmers/api-functions/api-assign.md
+++ b/docs/programmers/api-functions/api-assign.md
@@ -75,9 +75,9 @@ These are accessed in the template with
     {$contact.id}, {$contact.name},{$contact.email}
 
 To access more complex array assignments see
-[`{foreach}`](#language.function.foreach) and
-[`{section}`](#language.function.section)
+[`{foreach}`](../../designers/language-builtin-functions/language-function-foreach.md) and
+[`{section}`](../../designers/language-builtin-functions/language-function-section.md)
 
-See also [`getTemplateVars()`](#api.get.template.vars),
-[`clearAssign()`](#api.clear.assign), [`append()`](#api.append) and
-[`{assign}`](#language.function.assign)
+See also [`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md),
+[`clearAssign()`](../../programmers/api-functions/api-clear-assign.md), [`append()`](../../programmers/api-functions/api-append.md) and
+[`{assign}`](../../designers/language-builtin-functions/language-function-assign.md)

--- a/docs/programmers/api-functions/api-clear-all-assign.md
+++ b/docs/programmers/api-functions/api-clear-all-assign.md
@@ -28,7 +28,8 @@ clearAllAssign
 
        
 
-See also [`clearAssign()`](#api.clear.assign),
-[`clearConfig()`](#api.clear.config),
-[`getTemplateVars()`](#api.get.template.vars), [`assign()`](#api.assign)
-and [`append()`](#api.append)
+See also [`clearAssign()`](../../programmers/api-functions/api-clear-assign.md),
+[`clearConfig()`](../../programmers/api-functions/api-clear-config.md),
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md), 
+[`assign()`](../../programmers/api-functions/api-assign.md)
+and [`append()`](../../programmers/api-functions/api-append.md)

--- a/docs/programmers/api-functions/api-clear-all-cache.md
+++ b/docs/programmers/api-functions/api-clear-all-cache.md
@@ -33,5 +33,5 @@ cache files must be before they will get cleared.
 
        
 
-See also [`clearCache()`](#api.clear.cache),
-[`isCached()`](#api.is.cached) and the [caching](#caching) page.
+See also [`clearCache()`](../../programmers/api-functions/api-clear-cache.md),
+[`isCached()`](../../programmers/api-functions/api-is-cached.md) and the [caching](../../api/caching/basics.md) page.

--- a/docs/programmers/api-functions/api-clear-assign.md
+++ b/docs/programmers/api-functions/api-clear-assign.md
@@ -26,7 +26,8 @@ This can be a single value, or an array of values.
 
        
 
-See also [`clearAllAssign()`](#api.clear.all.assign),
-[`clearConfig()`](#api.clear.config),
-[`getTemplateVars()`](#api.get.template.vars), [`assign()`](#api.assign)
-and [`append()`](#api.append)
+See also [`clearAllAssign()`](../../programmers/api-functions/api-clear-all-assign.md),
+[`clearConfig()`](../../programmers/api-functions/api-clear-config.md),
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md), 
+[`assign()`](../../programmers/api-functions/api-assign.md)
+and [`append()`](../../programmers/api-functions/api-append.md)

--- a/docs/programmers/api-functions/api-clear-cache.md
+++ b/docs/programmers/api-functions/api-clear-cache.md
@@ -29,9 +29,9 @@ expire\_time
     template, you can clear a specific cache by supplying the `cache_id`
     as the second parameter.
 
--   You can also pass a [`$compile_id`](#variable.compile.id) as a third
+-   You can also pass a [`$compile_id`](../api-variables/variable-compile-id.md) as a third
     parameter. You can [group templates together](#caching.groups) so
-    they can be removed as a group, see the [caching section](#caching)
+    they can be removed as a group, see the [caching section](../../api/caching/basics.md)
     for more information.
 
 -   As an optional fourth parameter, you can supply a minimum age in
@@ -56,5 +56,5 @@ expire\_time
 
        
 
-See also [`clearAllCache()`](#api.clear.all.cache) and
-[`caching`](#caching) section.
+See also [`clearAllCache()`](../../programmers/api-functions/api-clear-all-cache.md) and
+[`caching`](../../api/caching/basics.md) section.

--- a/docs/programmers/api-functions/api-clear-compiled-tpl.md
+++ b/docs/programmers/api-functions/api-clear-compiled-tpl.md
@@ -23,8 +23,8 @@ exp\_time
 
 This clears the compiled version of the specified template resource, or
 all compiled template files if one is not specified. If you pass a
-[`$compile_id`](#variable.compile.id) only the compiled template for
-this specific [`$compile_id`](#variable.compile.id) is cleared. If you
+[`$compile_id`](../api-variables/variable-compile-id.md) only the compiled template for
+this specific [`$compile_id`](../api-variables/variable-compile-id.md) is cleared. If you
 pass an exp\_time, then only compiled templates older than `exp_time`
 seconds are cleared, by default all compiled templates are cleared
 regardless of their age. This function is for advanced use only, not
@@ -41,4 +41,4 @@ normally needed.
 
        
 
-See also [`clearCache()`](#api.clear.cache).
+See also [`clearCache()`](../../programmers/api-functions/api-clear-cache.md).

--- a/docs/programmers/api-functions/api-clear-config.md
+++ b/docs/programmers/api-functions/api-clear-config.md
@@ -13,7 +13,7 @@ string
 
 var
 
-This clears all assigned [config variables](#language.config.variables).
+This clears all assigned [config variables](../../designers/language-variables/language-config-variables.md).
 If a variable name is supplied, only that variable is cleared.
 
 
@@ -27,9 +27,9 @@ If a variable name is supplied, only that variable is cleared.
 
        
 
-See also [`getConfigVars()`](#api.get.config.vars),
-[`config variables`](#language.config.variables),
-[`config files`](#config.files),
-[`{config_load}`](#language.function.config.load),
-[`configLoad()`](#api.config.load) and
-[`clearAssign()`](#api.clear.assign).
+See also [`getConfigVars()`](../../programmers/api-functions/api-get-config-vars.md),
+[`config variables`](../../designers/language-variables/language-config-variables.md),
+[`config files`](../../designers/config-files.md),
+[`{config_load}`](../../designers/language-builtin-functions/language-function-config-load.md),
+[`configLoad()`](../../programmers/api-functions/api-config-load.md) and
+[`clearAssign()`](../../programmers/api-functions/api-clear-assign.md).

--- a/docs/programmers/api-functions/api-config-load.md
+++ b/docs/programmers/api-functions/api-config-load.md
@@ -17,17 +17,17 @@ string
 
 section
 
-This loads [config file](#config.files) data and assigns it to the
+This loads [config file](../../designers/config-files.md) data and assigns it to the
 template. This works identically to the template
-[`{config_load}`](#language.function.config.load) function.
+[`{config_load}`](../../designers/language-builtin-functions/language-function-config-load.md) function.
 
 > **Note**
 >
 > As of Smarty 2.4.0, assigned template variables are kept across
-> invocations of [`fetch()`](#api.fetch) and
-> [`display()`](#api.display). Config vars loaded from `configLoad()`
+> invocations of [`fetch()`](../../programmers/api-functions/api-fetch.md) and
+> [`display()`](../../programmers/api-functions/api-display.md). Config vars loaded from `configLoad()`
 > are always global in scope. Config files are also compiled for faster
-> execution, and respect the [`$force_compile`](#variable.force.compile)
+> execution, and respect the [`$force_compile`](../api-variables/variable-force-compile.md)
 > and [`$compile_check`](#variable.compile.check) settings.
 
 
@@ -41,7 +41,7 @@ template. This works identically to the template
 
        
 
-See also [`{config_load}`](#language.function.config.load),
-[`getConfigVars()`](#api.get.config.vars),
-[`clearConfig()`](#api.clear.config), and
-[`config variables`](#language.config.variables)
+See also [`{config_load}`](../../designers/language-builtin-functions/language-function-config-load.md),
+[`getConfigVars()`](../../programmers/api-functions/api-get-config-vars.md),
+[`clearConfig()`](../../programmers/api-functions/api-clear-config.md) and
+[`config variables`](../../designers/language-variables/language-config-variables.md)

--- a/docs/programmers/api-functions/api-create-data.md
+++ b/docs/programmers/api-functions/api-create-data.md
@@ -48,5 +48,5 @@ be used to control which variables are seen by which templates.
 
         
 
-See also [`display()`](#api.display), and
+See also [`display()`](../../programmers/api-functions/api-display.md), and
 [`createTemplate()`](#api.create.template),

--- a/docs/programmers/api-functions/api-create-template.md
+++ b/docs/programmers/api-functions/api-create-template.md
@@ -70,10 +70,10 @@ array
 data
 
 This creates a template object which later can be rendered by the
-[display](#api.display) or [fetch](#api.fetch) method. It uses the
+[display](../../programmers/api-functions/api-display.md) or [fetch](../../programmers/api-functions/api-fetch.md) method. It uses the
 following parameters:
 
--   `template` must be a valid [template resource](#resources) type and
+-   `template` must be a valid [template resource](../../api/resources.md) type and
     path.
 
 <!-- -->
@@ -95,5 +95,5 @@ following parameters:
 
         
 
-See also [`display()`](#api.display), and
+See also [`display()`](../../programmers/api-functions/api-display.md), and
 [`templateExists()`](#api.template.exists).

--- a/docs/programmers/api-functions/api-disable-security.md
+++ b/docs/programmers/api-functions/api-disable-security.md
@@ -11,5 +11,5 @@ disableSecurity
 
 This disables security checking on templates.
 
-See also [`enableSecurity()`](#api.enable.security), and
+See also [`enableSecurity()`](../../programmers/api-functions/api-enable-security.md), and
 [Security](#advanced.features.security).

--- a/docs/programmers/api-functions/api-display.md
+++ b/docs/programmers/api-functions/api-display.md
@@ -22,10 +22,10 @@ string
 compile\_id
 
 This displays the contents of a template. To return the contents of a
-template into a variable, use [`fetch()`](#api.fetch). Supply a valid
-[template resource](#resources) type and path. As an optional second
+template into a variable, use [`fetch()`](../../programmers/api-functions/api-fetch.md). Supply a valid
+[template resource](../../api/resources.md) type and path. As an optional second
 parameter, you can pass a `$cache_id`, see the [caching
-section](#caching) for more information.
+section](../../api/caching/basics.md) for more information.
 
 PARAMETER.COMPILEID
 
@@ -60,7 +60,7 @@ PARAMETER.COMPILEID
 
        
 
-Use the syntax for [template resources](#resources) to display files
+Use the syntax for [template resources](../../api/resources.md) to display files
 outside of the [`$template_dir`](#variable.template.dir) directory.
 
 
@@ -80,5 +80,5 @@ outside of the [`$template_dir`](#variable.template.dir) directory.
 
        
 
-See also [`fetch()`](#api.fetch) and
+See also [`fetch()`](../../programmers/api-functions/api-fetch.md) and
 [`templateExists()`](#api.template.exists).

--- a/docs/programmers/api-functions/api-enable-security.md
+++ b/docs/programmers/api-functions/api-enable-security.md
@@ -37,5 +37,5 @@ parameters:
 For the details how to setup a security policy see the
 [Security](#advanced.features.security) section.
 
-See also [`disableSecurity()`](#api.disable.security), and
+See also [`disableSecurity()`](../../programmers/api-functions/api-disable-security.md), and
 [Security](#advanced.features.security).

--- a/docs/programmers/api-functions/api-fetch.md
+++ b/docs/programmers/api-functions/api-fetch.md
@@ -21,10 +21,10 @@ string
 
 compile\_id
 
-This returns the template output instead of [displaying](#api.display)
-it. Supply a valid [template resource](#resources) type and path. As an
-optional second parameter, you can pass a `$cache id`, see the [caching
-section](#caching) for more information.
+This returns the template output instead of [displaying](../../programmers/api-functions/api-display.md)
+it. Supply a valid [template resource](../../api/resources.md) type and path. As an
+optional second parameter, you can pass a `$cache id`, see the 
+[caching section](../../api/caching/basics.md) for more information.
 
 PARAMETER.COMPILEID
 
@@ -72,20 +72,19 @@ The `email_body.tpl` template
 The php script using the PHP [`mail()`](https://www.php.net/function.mail)
 function
 
+```php
+<?php
 
-    <?php
+// get $contact_info from db or other resource here
 
-    // get $contact_info from db or other resource here
+$smarty->assign('contact_info',$contact_info);
+$smarty->assign('login_url',"http://{$_SERVER['SERVER_NAME']}/login");
 
-    $smarty->assign('contact_info',$contact_info);
-    $smarty->assign('login_url',"http://{$_SERVER['SERVER_NAME']}/login");
+mail($contact_info['email'], 'Thank You', $smarty->fetch('email_body.tpl'));
 
-    mail($contact_info['email'], 'Thank You', $smarty->fetch('email_body.tpl'));
+?>
+```
 
-    ?>
-
-        
-
-See also [`{fetch}`](#language.function.fetch)
-[`display()`](#api.display), [`{eval}`](#language.function.eval), and
+See also [`{fetch}`](../../designers/language-custom-functions/language-function-fetch.md)
+[`display()`](api-display.md), [`{eval}`](../../designers/language-custom-functions/language-function-eval.md), and
 [`templateExists()`](#api.template.exists).

--- a/docs/programmers/api-functions/api-get-config-vars.md
+++ b/docs/programmers/api-functions/api-get-config-vars.md
@@ -13,8 +13,8 @@ string
 
 varname
 
-If no parameter is given, an array of all loaded [config
-variables](#language.config.variables) is returned.
+If no parameter is given, an array of all loaded 
+[config variables](../../designers/language-variables/language-config-variables.md) is returned.
 
 
     <?php
@@ -31,7 +31,7 @@ variables](#language.config.variables) is returned.
 
        
 
-See also [`clearConfig()`](#api.clear.config),
-[`{config_load}`](#language.function.config.load),
-[`configLoad()`](#api.config.load) and
-[`getTemplateVars()`](#api.get.template.vars).
+See also [`clearConfig()`](../../programmers/api-functions/api-clear-config.md),
+[`{config_load}`](../../designers/language-builtin-functions/language-function-config-load.md),
+[`configLoad()`](../../programmers/api-functions/api-config-load.md) and
+[`getTemplateVars()`](../../programmers/api-functions/api-get-template-vars.md).

--- a/docs/programmers/api-functions/api-get-plugins-dir.md
+++ b/docs/programmers/api-functions/api-get-plugins-dir.md
@@ -26,6 +26,6 @@ getPluginsDir
 
        
 
-See also [`setPluginsDir()`](#api.set.plugins.dir),
-[`addPluginsDir()`](#api.add.plugins.dir) and
+See also [`setPluginsDir()`](../../programmers/api-functions/api-set-plugins-dir.md),
+[`addPluginsDir()`](../../programmers/api-functions/api-add-plugins-dir.md) and
 [`$plugins_dir`](#variable.plugins.dir).

--- a/docs/programmers/api-functions/api-get-registered-object.md
+++ b/docs/programmers/api-functions/api-get-registered-object.md
@@ -14,7 +14,7 @@ string
 object\_name
 
 This is useful from within a custom function when you need direct access
-to a [registered object](#api.register.object). See the
+to a [registered object](../../programmers/api-functions/api-register-object.md). See the
 [objects](#advanced.features.objects) page for more info.
 
 
@@ -31,6 +31,6 @@ to a [registered object](#api.register.object). See the
 
        
 
-See also [`registerObject()`](#api.register.object),
-[`unregisterObject()`](#api.unregister.object) and [objects
+See also [`registerObject()`](../../programmers/api-functions/api-register-object.md),
+[`unregisterObject()`](../../programmers/api-functions/api-unregister-object.md) and [objects
 page](#advanced.features.objects)

--- a/docs/programmers/api-functions/api-get-template-vars.md
+++ b/docs/programmers/api-functions/api-get-template-vars.md
@@ -13,7 +13,7 @@ string
 
 varname
 
-If no parameter is given, an array of all [assigned](#api.assign)
+If no parameter is given, an array of all [assigned](../../programmers/api-functions/api-assign.md)
 variables are returned.
 
 
@@ -30,8 +30,8 @@ variables are returned.
 
        
 
-See also [`assign()`](#api.assign),
-[`{assign}`](#language.function.assign), [`append()`](#api.append),
-[`clearAssign()`](#api.clear.assign),
-[`clearAllAssign()`](#api.clear.all.assign) and
-[`getConfigVars()`](#api.get.config.vars)
+See also [`assign()`](../../programmers/api-functions/api-assign.md),
+[`{assign}`](../../designers/language-builtin-functions/language-function-assign.md), [`append()`](../../programmers/api-functions/api-append.md),
+[`clearAssign()`](../../programmers/api-functions/api-clear-assign.md),
+[`clearAllAssign()`](../../programmers/api-functions/api-clear-all-assign.md) and
+[`getConfigVars()`](../../programmers/api-functions/api-get-config-vars.md)

--- a/docs/programmers/api-functions/api-is-cached.md
+++ b/docs/programmers/api-functions/api-is-cached.md
@@ -23,31 +23,31 @@ compile\_id
 
 -   This only works if [`$caching`](#variable.caching) is set to one of
     `\Smarty\Smarty::CACHING_LIFETIME_CURRENT` or
-    `\Smarty\Smarty::CACHING_LIFETIME_SAVED` to enable caching. See the [caching
-    section](#caching) for more info.
+    `\Smarty\Smarty::CACHING_LIFETIME_SAVED` to enable caching. See the
+    [caching section](../../api/caching/basics.md) for more info.
 
 -   You can also pass a `$cache_id` as an optional second parameter in
     case you want [multiple caches](#caching.multiple.caches) for the
     given template.
 
--   You can supply a [`$compile id`](#variable.compile.id) as an
+-   You can supply a [`$compile id`](../api-variables/variable-compile-id.md) as an
     optional third parameter. If you omit that parameter the persistent
-    [`$compile_id`](#variable.compile.id) is used if its set.
+    [`$compile_id`](../api-variables/variable-compile-id.md) is used if its set.
 
 -   If you do not want to pass a `$cache_id` but want to pass a
-    [`$compile_id`](#variable.compile.id) you have to pass NULL as a
+    [`$compile_id`](../api-variables/variable-compile-id.md) you have to pass NULL as a
     `$cache_id`.
 
 > **Note**
 >
 > If `isCached()` returns TRUE it actually loads the cached output and
 > stores it internally. Any subsequent call to
-> [`display()`](#api.display) or [`fetch()`](#api.fetch) will return
+> [`display()`](../../programmers/api-functions/api-display.md) or [`fetch()`](../../programmers/api-functions/api-fetch.md) will return
 > this internally stored output and does not try to reload the cache
 > file. This prevents a race condition that may occur when a second
 > process clears the cache between the calls to `isCached()` and to
-> [`display()`](#api.display) in the example above. This also means
-> calls to [`clearCache()`](#api.clear.cache) and other changes of the
+> [`display()`](../../programmers/api-functions/api-display.md) in the example above. This also means
+> calls to [`clearCache()`](../../programmers/api-functions/api-clear-cache.md) and other changes of the
 > cache-settings may have no effect after `isCached()` returned TRUE.
 
 
@@ -76,6 +76,6 @@ compile\_id
 
        
 
-See also [`clearCache()`](#api.clear.cache),
-[`clearAllCache()`](#api.clear.all.cache), and [caching
-section](#caching).
+See also [`clearCache()`](../../programmers/api-functions/api-clear-cache.md),
+[`clearAllCache()`](../../programmers/api-functions/api-clear-all-cache.md)
+and [caching section](../../api/caching/basics.md).

--- a/docs/programmers/api-functions/api-load-filter.md
+++ b/docs/programmers/api-functions/api-load-filter.md
@@ -37,5 +37,5 @@ specifies the `name` of the filter plugin.
 
        
 
-See also [`registerFilter()`](#api.register.filter) and [advanced
+See also [`registerFilter()`](../../programmers/api-functions/api-register-filter.md) and [advanced
 features](#advanced.features).

--- a/docs/programmers/api-functions/api-register-cacheresource.md
+++ b/docs/programmers/api-functions/api-register-cacheresource.md
@@ -36,5 +36,5 @@ how to create custom CacheResources.
 
        
 
-See also [`unregisterCacheResource()`](#api.unregister.cacheresource)
+See also [`unregisterCacheResource()`](../../programmers/api-functions/api-unregister-cacheresource.md)
 and the [Custom CacheResource Implementation](#caching.custom) section.

--- a/docs/programmers/api-functions/api-register-class.md
+++ b/docs/programmers/api-functions/api-register-class.md
@@ -64,5 +64,5 @@ otherwise. If security is enabled, classes registered with
 
        
 
-See also [`registerObject()`](#api.register.object), and
+See also [`registerObject()`](../../programmers/api-functions/api-register-object.md), and
 [Security](#advanced.features.security).

--- a/docs/programmers/api-functions/api-register-filter.md
+++ b/docs/programmers/api-functions/api-register-filter.md
@@ -33,12 +33,12 @@ postfilters](#advanced.features.postfilters) for more information on how
 to setup a postfiltering function.
 
 A [outputfilter](#plugins.outputfilters) operates on a template\'s
-output before it is [displayed](#api.display). See [template output
+output before it is [displayed](../../programmers/api-functions/api-display.md). See [template output
 filters](#advanced.features.outputfilters) for more information on how
 to set up an output filter function.
 
-See also [`unregisterFilter()`](#api.unregister.filter),
-[`loadFilter()`](#api.load.filter), [template pre
+See also [`unregisterFilter()`](../../programmers/api-functions/api-unregister-filter.md),
+[`loadFilter()`](../../programmers/api-functions/api-load-filter.md), [template pre
 filters](#advanced.features.prefilters) [template post
 filters](#advanced.features.postfilters) [template output
 filters](#advanced.features.outputfilters) section.

--- a/docs/programmers/api-functions/api-register-object.md
+++ b/docs/programmers/api-functions/api-register-object.md
@@ -40,5 +40,5 @@ block\_methods
 See the [objects section](#advanced.features.objects) for more
 information.
 
-See also [`getRegisteredObject()`](#api.get.registered.object), and
-[`unregisterObject()`](#api.unregister.object).
+See also [`getRegisteredObject()`](../../programmers/api-functions/api-get-registered-object.md), and
+[`unregisterObject()`](../../programmers/api-functions/api-unregister-object.md).

--- a/docs/programmers/api-functions/api-register-plugin.md
+++ b/docs/programmers/api-functions/api-register-plugin.md
@@ -103,7 +103,7 @@ In the template, use `ss` to strip slashes.
     {$var|ss}
     ?>
 
-See also [`unregisterPlugin()`](#api.unregister.plugin), [plugin
+See also [`unregisterPlugin()`](../../programmers/api-functions/api-unregister-plugin.md), [plugin
 functions](#plugins.functions), [plugin block
 functions](#plugins.block.functions), [plugin compiler
 functions](#plugins.compiler.functions), and the [creating plugin

--- a/docs/programmers/api-functions/api-register-resource.md
+++ b/docs/programmers/api-functions/api-register-resource.md
@@ -17,9 +17,9 @@ Smarty\_resource
 
 resource\_handler
 
-Use this to dynamically register a [Resource plugin](#resources) with
+Use this to dynamically register a [Resource plugin](../../api/resources.md) with
 Smarty. Pass in the `name` of the Resource and the object extending
-Smarty\_Resource. See [template resources](#resources) for more
+Smarty\_Resource. See [template resources](../../api/resources.md) for more
 information on how to setup a function for fetching templates.
 
 > **Note**
@@ -42,5 +42,5 @@ information on how to setup a function for fetching templates.
 
        
 
-See also [`unregisterResource()`](#api.unregister.resource) and the
-[template resources](#resources) section.
+See also [`unregisterResource()`](../../programmers/api-functions/api-unregister-resource.md) and the
+[template resources](../../api/resources.md) section.

--- a/docs/programmers/api-functions/api-set-plugins-dir.md
+++ b/docs/programmers/api-functions/api-set-plugins-dir.md
@@ -41,6 +41,6 @@ plugins\_dir
 
        
 
-See also [`getPluginsDir()`](#api.get.plugins.dir),
-[`addPluginsDir()`](#api.add.plugins.dir) and
+See also [`getPluginsDir()`](../../programmers/api-functions/api-get-plugins-dir.md),
+[`addPluginsDir()`](../../programmers/api-functions/api-add-plugins-dir.md) and
 [`$plugins_dir`](#variable.plugins.dir).

--- a/docs/programmers/api-functions/api-unregister-cacheresource.md
+++ b/docs/programmers/api-functions/api-unregister-cacheresource.md
@@ -24,5 +24,5 @@ Pass in the `name` of the CacheResource.
 
        
 
-See also [`registerCacheResource()`](#api.register.cacheresource) and
+See also [`registerCacheResource()`](../../programmers/api-functions/api-register-cacheresource.md) and
 the [Custom CacheResource Implementation](#caching.custom) section.

--- a/docs/programmers/api-functions/api-unregister-filter.md
+++ b/docs/programmers/api-functions/api-unregister-filter.md
@@ -20,4 +20,4 @@ callback
 Use this to dynamically unregister filters. It uses the following
 parameters:
 
-See also [`registerFilter()`](#api.register.filter).
+See also [`registerFilter()`](../../programmers/api-functions/api-register-filter.md).

--- a/docs/programmers/api-functions/api-unregister-object.md
+++ b/docs/programmers/api-functions/api-unregister-object.md
@@ -13,5 +13,5 @@ string
 
 object\_name
 
-See also [`registerObject()`](#api.register.object) and [objects
+See also [`registerObject()`](../../programmers/api-functions/api-register-object.md) and [objects
 section](#advanced.features.objects)

--- a/docs/programmers/api-functions/api-unregister-plugin.md
+++ b/docs/programmers/api-functions/api-unregister-plugin.md
@@ -18,7 +18,7 @@ string
 name
 
 This method unregisters plugins which previously have been registered by
-[registerPlugin()](#api.register.plugin), It uses the following
+[registerPlugin()](../../programmers/api-functions/api-register-plugin.md), It uses the following
 parameters:
 
 <!-- -->
@@ -33,4 +33,4 @@ parameters:
 
        
 
-See also [`registerPlugin()`](#api.register.plugin).
+See also [`registerPlugin()`](../../programmers/api-functions/api-register-plugin.md).

--- a/docs/programmers/api-functions/api-unregister-resource.md
+++ b/docs/programmers/api-functions/api-unregister-resource.md
@@ -24,5 +24,5 @@ Pass in the `name` of the resource.
 
        
 
-See also [`registerResource()`](#api.register.resource) and [template
-resources](#resources)
+See also [`registerResource()`](../../programmers/api-functions/api-register-resource.md) 
+and [template resources](../../api/resources.md)

--- a/docs/programmers/api-variables/variable-auto-literal.md
+++ b/docs/programmers/api-variables/variable-auto-literal.md
@@ -14,4 +14,4 @@ auto\_literal to false.
             
 :::
 
-See also [Escaping Smarty parsing](#language.escaping),
+See also [Escaping Smarty parsing](../../designers/language-basic-syntax/language-escaping.md).

--- a/docs/programmers/api-variables/variable-cache-dir.md
+++ b/docs/programmers/api-variables/variable-cache-dir.md
@@ -32,4 +32,4 @@ See also [`getCacheDir()`](#api.get.cache.dir),
 [`$use_sub_dirs`](#variable.use.sub.dirs),
 [`$cache_lifetime`](#variable.cache.lifetime),
 [`$cache_modified_check`](#variable.cache.modified.check) and the
-[caching section](#caching).
+[caching section](../../api/caching/basics.md).

--- a/docs/programmers/api-variables/variable-cache-id.md
+++ b/docs/programmers/api-variables/variable-cache-id.md
@@ -6,6 +6,6 @@ Persistent cache\_id identifier. As an alternative to passing the same
 `$cache_id` and it will be used implicitly thereafter.
 
 With a `$cache_id` you can have multiple cache files for a single call
-to [`display()`](#api.display) or [`fetch()`](#api.fetch) depending for
-example from different content of the same template. See the [caching
-section](#caching) for more information.
+to [`display()`](../../programmers/api-functions/api-display.md) or [`fetch()`](../../programmers/api-functions/api-fetch.md) depending on for
+example different content of the same template. See the 
+[caching section](../../api/caching/basics.md) for more information.

--- a/docs/programmers/api-variables/variable-cache-lifetime.md
+++ b/docs/programmers/api-variables/variable-cache-lifetime.md
@@ -19,12 +19,12 @@ Once this time has expired, the cache will be regenerated.
 -   If you want to give certain templates their own cache lifetime, you
     could do this by setting [`$caching`](#variable.caching) =
     \Smarty\Smarty::CACHING\_LIFETIME\_SAVED, then set `$cache_lifetime` to a
-    unique value just before calling [`display()`](#api.display) or
-    [`fetch()`](#api.fetch).
+    unique value just before calling [`display()`](../../programmers/api-functions/api-display.md) or
+    [`fetch()`](../../programmers/api-functions/api-fetch.md).
 
 If [`$force_compile`](#variable.force.compile) is enabled, the cache
 files will be regenerated every time, effectively disabling caching. You
 can clear all the cache files with the
-[`clear_all_cache()`](#api.clear.all.cache) function, or individual
-cache files (or groups) with the [`clear_cache()`](#api.clear.cache)
+[`clear_all_cache()`](../../programmers/api-functions/api-clear-all-cache.md) function, or individual
+cache files (or groups) with the [`clear_cache()`](../../programmers/api-functions/api-clear-cache.md)
 function.

--- a/docs/programmers/api-variables/variable-cache-modified-check.md
+++ b/docs/programmers/api-variables/variable-cache-modified-check.md
@@ -7,5 +7,5 @@ last visit, then a `'304: Not Modified'` header will be sent instead of
 the content.
 
 See also [`$caching`](#variable.caching),
-[`$cache_lifetime`](#variable.cache.lifetime), and the [caching
-section](#caching).
+[`$cache_lifetime`](#variable.cache.lifetime), and the 
+[caching section](../../api/caching/basics.md).

--- a/docs/programmers/api-variables/variable-caching.md
+++ b/docs/programmers/api-variables/variable-caching.md
@@ -21,7 +21,7 @@ same template.
     [`$cache_lifetime`](#variable.cache.lifetime) value at the time the
     cache was generated. This way you can set the
     [`$cache_lifetime`](#variable.cache.lifetime) just before
-    [fetching](#api.fetch) the template to have granular control over
+    [fetching](../../programmers/api-functions/api-fetch.md) the template to have granular control over
     when that particular cache expires. See also
     [`isCached()`](#api.is.cached).
 
@@ -35,4 +35,4 @@ same template.
 See also [`$cache_dir`](#variable.cache.dir),
 [`$cache_lifetime`](#variable.cache.lifetime),
 [`$cache_modified_check`](#variable.cache.modified.check),
-[`is_cached()`](#api.is.cached) and the [caching section](#caching).
+[`is_cached()`](#api.is.cached) and the [caching section](../../api/caching/basics.md).

--- a/docs/programmers/api-variables/variable-compile-dir.md
+++ b/docs/programmers/api-variables/variable-compile-dir.md
@@ -25,5 +25,5 @@ install](#installing.smarty.basic) for more info.
 
 See also [`getCompileDir()`](#api.get.compile.dir),
 [`setCompileDir()`](#api.set.compile.dir),
-[`$compile_id`](#variable.compile.id) and
+[`$compile_id`](../api-variables/variable-compile-id.md) and
 [`$use_sub_dirs`](#variable.use.sub.dirs).

--- a/docs/programmers/api-variables/variable-config-overwrite.md
+++ b/docs/programmers/api-variables/variable-config-overwrite.md
@@ -1,13 +1,13 @@
 \$config\_overwrite {#variable.config.overwrite}
 ===================
 
-If set to TRUE, the default then variables read in from [config
-files](#config.files) will overwrite each other. Otherwise, the
+If set to TRUE, the default then variables read in from 
+[config files](../../designers/config-files.md) will overwrite each other. Otherwise, the
 variables will be pushed onto an array. This is helpful if you want to
 store arrays of data in config files, just list each element multiple
 times.
 
-This examples uses [`{cycle}`](#language.function.cycle) to output a
+This examples uses [`{cycle}`](../../designers/language-custom-functions/language-function-cycle.md) to output a
 table with alternating red/green/blue row colors with
 `$config_overwrite` = FALSE.
 
@@ -21,7 +21,7 @@ The config file.
 
         
 
-The template with a [`{section}`](#language.function.section) loop.
+The template with a [`{section}`](../../designers/language-builtin-functions/language-function-section.md) loop.
 
 
     <table>
@@ -34,7 +34,8 @@ The template with a [`{section}`](#language.function.section) loop.
 
         
 
-See also [`{config_load}`](#language.function.config.load),
-[`getConfigVars()`](#api.get.config.vars),
-[`clearConfig()`](#api.clear.config), [`configLoad()`](#api.config.load)
-and the [config files section](#config.files).
+See also [`{config_load}`](../../designers/language-builtin-functions/language-function-config-load.md),
+[`getConfigVars()`](../../programmers/api-functions/api-get-config-vars.md),
+[`clearConfig()`](../../programmers/api-functions/api-clear-config.md), 
+[`configLoad()`](../../programmers/api-functions/api-config-load.md)
+and the [config files section](../../designers/config-files.md).

--- a/docs/programmers/api-variables/variable-debugging.md
+++ b/docs/programmers/api-variables/variable-debugging.md
@@ -2,16 +2,16 @@
 ===========
 
 This enables the [debugging console](#chapter.debugging.console). The
-console is a javascript popup window that informs you of the
-[included](#language.function.include) templates, variables
-[assigned](#api.assign) from php and [config file
-variables](#language.config.variables) for the current script. It does
+console is a JavaScript popup window that informs you of the
+[included](../../designers/language-builtin-functions/language-function-include.md) templates, variables
+[assigned](../../programmers/api-functions/api-assign.md) from php and 
+[config file variables](../../designers/language-variables/language-config-variables.md) for the current script. It does
 not show variables assigned within a template with the
-[`{assign}`](#language.function.assign) function.
+[`{assign}`](../../designers/language-builtin-functions/language-function-assign.md) function.
 
 The console can also be enabled from the url with
-[`$debugging_ctrl`](#variable.debugging.ctrl).
+[`$debugging_ctrl`](variable-debugging-ctrl.md).
 
-See also [`{debug}`](#language.function.debug),
-[`$debug_tpl`](#variable.debug_template), and
-[`$debugging_ctrl`](#variable.debugging.ctrl).
+See also [`{debug}`](../../designers/language-custom-functions/language-function-debug.md),
+[`$debug_tpl`](variable-debug-template.md), and
+[`$debugging_ctrl`](variable-debugging-ctrl.md).

--- a/docs/programmers/api-variables/variable-default-config-type.md
+++ b/docs/programmers/api-variables/variable-default-config-type.md
@@ -4,4 +4,4 @@
 This tells smarty what resource type to use for config files. The
 default value is `file`, meaning that `$smarty->configLoad('test.conf')`
 and `$smarty->configLoad('file:test.conf')` are identical in meaning.
-See the [resource](#resources) chapter for more details.
+See the [resource](../../api/resources.md) chapter for more details.

--- a/docs/programmers/api-variables/variable-default-resource-type.md
+++ b/docs/programmers/api-variables/variable-default-resource-type.md
@@ -4,4 +4,4 @@
 This tells smarty what resource type to use implicitly. The default
 value is `file`, meaning that `$smarty->display('index.tpl')` and
 `$smarty->display('file:index.tpl')` are identical in meaning. See the
-[resource](#resources) chapter for more details.
+[resource](../../api/resources.md) chapter for more details.

--- a/docs/programmers/api-variables/variable-error-reporting.md
+++ b/docs/programmers/api-variables/variable-error-reporting.md
@@ -3,7 +3,7 @@
 
 When this value is set to a non-null-value it\'s value is used as php\'s
 [`error_reporting`](https://www.php.net/error_reporting) level inside of
-[`display()`](#api.display) and [`fetch()`](#api.fetch).
+[`display()`](../../programmers/api-functions/api-display.md) and [`fetch()`](../../programmers/api-functions/api-fetch.md).
 
 Smarty 3.1.2 introduced the
 [`muteExpectedErrors()`](#api.mute.expected.errors) function. Calling

--- a/docs/programmers/api-variables/variable-force-compile.md
+++ b/docs/programmers/api-variables/variable-force-compile.md
@@ -3,7 +3,7 @@
 
 This forces Smarty to (re)compile templates on every invocation. This
 setting overrides [`$compile_check`](#variable.compile.check). By
-default this is FALSE. This is handy for development and
+default, this is FALSE. This is handy for development and
 [debugging](#chapter.debugging.console). It should never be used in a
-production environment. If [`$caching`](#variable.caching) is enabled,
+production environment. If [`$caching`](variable-caching.md) is enabled,
 the cache file(s) will be regenerated every time.

--- a/docs/programmers/api-variables/variable-merge-compiled-includes.md
+++ b/docs/programmers/api-variables/variable-merge-compiled-includes.md
@@ -24,4 +24,4 @@ have to be enabled for the `inline` merge.
 > This is a compile time option. If you change the setting you must make
 > sure that the templates get recompiled.
 
-See also [`{include}`](#language.function.include) tag
+See also [`{include}`](../../designers/language-builtin-functions/language-function-include.md) tag.

--- a/docs/programmers/api-variables/variable-template-dir.md
+++ b/docs/programmers/api-variables/variable-template-dir.md
@@ -20,7 +20,7 @@ found.
 > [`setTemplateDir()`](#api.set.template.dir) and
 > [`addTemplateDir()`](#api.add.template.dir) instead.
 
-See also [`Template Resources`](#resources),
+See also [`Template Resources`](../../api/resources.md),
 [`getTemplateDir()`](#api.get.template.dir),
 [`setTemplateDir()`](#api.set.template.dir) and
 [`addTemplateDir()`](#api.add.template.dir).

--- a/docs/programmers/api-variables/variable-use-sub-dirs.md
+++ b/docs/programmers/api-variables/variable-use-sub-dirs.md
@@ -26,6 +26,6 @@ almost nothing.
 >
 > -   Safe\_mode is being deprecated in PHP6.
 >
-See also [`$compile_id`](#variable.compile.id),
+See also [`$compile_id`](../api-variables/variable-compile-id.md),
 [`$cache_dir`](#variable.cache.dir), and
 [`$compile_dir`](#variable.compile.dir).


### PR DESCRIPTION
This PR fixes many of the broken links in the documentation.

There are still broken links remaining. For some of the links just no file exists to point at. Some are for variables that do no longer exist or are not accessible anymore. Some others seem to be newish functionality that need documentation.