### PR TITLE
Fix {strip} block removing spaces between HTML attributes.

### DIFF
--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -571,6 +571,7 @@ class Template extends BaseCompiler {
 			'#(:SMARTY@!@|>)[\040\011]*[\n]\s*(?=@!@SMARTY:|<)#s' => '\1\2',
 			// remove multiple spaces between attributes (but not in attribute values!)
 			'#(([a-z0-9]\s*=\s*("[^"]*?")|(\'[^\']*?\'))|<[a-z0-9_]+)\s+([a-z/>])#is' => '\1 \5',
+			'#"[\t\s]*\n+[\t\s]*([a-z-]+=")#is' => '" \1',
 			'#>[\040\011]+$#Ss' => '> ',
 			'#>[\040\011]*[\n]\s*$#Ss' => '>',
 			$this->stripRegEx => '',

--- a/tests/UnitTests/TemplateSource/TagTests/Strip/CompileStripTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Strip/CompileStripTest.php
@@ -61,6 +61,8 @@ class CompileStripTest extends PHPUnit_Smarty
                            '<ul><li><a href="#">BlaBla</a></li><li><a href="#">BlaBla</a></li></ul>', '', $i ++),
                      array("\n            <textarea>\n\n                some text\n\n            </textarea>   foo\n    bar\n",
                            "<textarea>\n\n                some text\n\n            </textarea>   foobar", '', $i ++),
+                     array("<a\n       href=\"{'genLink'}\"\n    target=\"_blank\">link-text</a>", '<a href="genLink" target="_blank">link-text</a>', '', $i ++),
+                     array("<span\nonclick=\"fn({'param'});\"\nclass=\"c\">text</span>", '<span onclick="fn(param);" class="c">text</span>', '', $i ++),
                      // variable in html tag
                      array("\n    <b><c>c</c></b>\n", '<b><c>c</c></b>', '', $i ++),
                      array("\n    <b> <c>c</c></b>\n", '<b> <c>c</c></b>', '', $i ++),


### PR DESCRIPTION
### Context
{strip} removed spaces between HTML attributes in some cases like e.g.,
 `<a href=\"{'genLink'}\"\n target=\"_blank\">`. This is due to the Smarty tag in the middle splitting the text block up and so the regex does not recognize the HTML attribute.

### Changes
This PR adds a regex to look for a `"` (the end of an attribute) followed by something that looks like another attribute `[a-z-]+="`. In this case the space in the middle is replaced by a single space instead of being completely removed. The PR also adds two tests for this case which resemble the circumstances under which I encountered this bug.