### PR TITLE
Add type validation for security_policy property.

### DIFF
--- a/src/Compile/ModifierCompiler.php
+++ b/src/Compile/ModifierCompiler.php
@@ -48,9 +48,10 @@ class ModifierCompiler extends Base {
 
 			$modifier_params[0] = $output;
 			$params = implode(',', $modifier_params);
+			$securityPolicy = $compiler->getSmarty()->getSecurityPolicy();
 
-			if (!is_object($compiler->getSmarty()->security_policy)
-				|| $compiler->getSmarty()->security_policy->isTrustedModifier($modifier, $compiler)
+			if ($securityPolicy === null
+				|| $securityPolicy->isTrustedModifier($modifier, $compiler)
 			) {
 
 				if ($handler = $compiler->getModifierCompiler($modifier)) {

--- a/src/Compile/SpecialVariableCompiler.php
+++ b/src/Compile/SpecialVariableCompiler.php
@@ -45,8 +45,9 @@ class SpecialVariableCompiler extends Base {
 		if ($variable === false) {
 			$compiler->trigger_template_error("special \$Smarty variable name index can not be variable", null, true);
 		}
-		if (!isset($compiler->getSmarty()->security_policy)
-			|| $compiler->getSmarty()->security_policy->isTrustedSpecialSmartyVar($variable, $compiler)
+		$securityPolicy = $compiler->getSmarty()->getSecurityPolicy();
+		if ($securityPolicy === null
+			|| $securityPolicy->isTrustedSpecialSmartyVar($variable, $compiler)
 		) {
 			switch ($variable) {
 				case 'foreach':
@@ -58,8 +59,8 @@ class SpecialVariableCompiler extends Base {
 				case 'now':
 					return 'time()';
 				case 'cookies':
-					if (isset($compiler->getSmarty()->security_policy)
-						&& !$compiler->getSmarty()->security_policy->allow_super_globals
+					if ($securityPolicy !== null
+						&& !$securityPolicy->allow_super_globals
 					) {
 						$compiler->trigger_template_error("(secure mode) super globals not permitted");
 						break;
@@ -72,8 +73,8 @@ class SpecialVariableCompiler extends Base {
 				case 'server':
 				case 'session':
 				case 'request':
-					if (isset($compiler->getSmarty()->security_policy)
-						&& !$compiler->getSmarty()->security_policy->allow_super_globals
+					if ($securityPolicy !== null
+						&& !$securityPolicy->allow_super_globals
 					) {
 						$compiler->trigger_template_error("(secure mode) super globals not permitted");
 						break;
@@ -83,7 +84,7 @@ class SpecialVariableCompiler extends Base {
 				case 'template':
 					return '$_smarty_tpl->template_resource';
 				case 'template_object':
-					if (isset($compiler->getSmarty()->security_policy)) {
+					if ($securityPolicy !== null) {
 						$compiler->trigger_template_error("(secure mode) template_object not permitted");
 						break;
 					}
@@ -93,8 +94,8 @@ class SpecialVariableCompiler extends Base {
 				case 'version':
 					return "\\Smarty\\Smarty::SMARTY_VERSION";
 				case 'const':
-					if (isset($compiler->getSmarty()->security_policy)
-						&& !$compiler->getSmarty()->security_policy->allow_constants
+					if ($securityPolicy !== null
+						&& !$securityPolicy->allow_constants
 					) {
 						$compiler->trigger_template_error("(secure mode) constants not permitted");
 						break;

--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -606,8 +606,8 @@ class Template extends BaseCompiler {
 	 */
 	public function getTagCompiler($tag): ?\Smarty\Compile\CompilerInterface {
         $tag = strtolower($tag);
-
-		if (isset($this->smarty->security_policy) && !$this->smarty->security_policy->isTrustedTag($tag, $this)) {
+		$securityPolicy = $this->smarty->getSecurityPolicy();
+		if ($securityPolicy !== null && !$securityPolicy->isTrustedTag($tag, $this)) {
 			return null;
 		}
 
@@ -628,8 +628,8 @@ class Template extends BaseCompiler {
 	 * @return bool|\Smarty\Compile\Modifier\ModifierCompilerInterface tag compiler object or false if not found or untrusted by security policy
 	 */
 	public function getModifierCompiler($modifier) {
-
-		if (isset($this->smarty->security_policy) && !$this->smarty->security_policy->isTrustedModifier($modifier, $this)) {
+		$securityPolicy = $this->smarty->getSecurityPolicy();
+		if ($securityPolicy !== null && !$securityPolicy->isTrustedModifier($modifier, $this)) {
 			return false;
 		}
 
@@ -1111,10 +1111,11 @@ class Template extends BaseCompiler {
 		// $args contains the attributes parsed and compiled by the lexer/parser
 
 		$this->handleNocacheFlag($args);
+		$securityPolicy = $this->smarty->getSecurityPolicy();
 
 		// compile built-in tags
 		if ($tagCompiler = $this->getTagCompiler($tag)) {
-			if (!isset($this->smarty->security_policy) || $this->smarty->security_policy->isTrustedTag($tag, $this)) {
+			if ($securityPolicy === null || $securityPolicy->isTrustedTag($tag, $this)) {
 				$this->tag_nocache = $this->tag_nocache | !$tagCompiler->isCacheable();
 				$_output = $tagCompiler->compile($args, $this, $parameter);
 				if (!empty($parameter['modifierlist'])) {
@@ -1147,7 +1148,7 @@ class Template extends BaseCompiler {
 
 		// check if tag is a function
 		if ($this->smarty->getFunctionHandler($tag)) {
-			if (!isset($this->smarty->security_policy) || $this->smarty->security_policy->isTrustedTag($tag, $this)) {
+			if ($securityPolicy === null || $securityPolicy->isTrustedTag($tag, $this)) {
 				return (new \Smarty\Compile\PrintExpressionCompiler())->compile(
 					['nofilter'], // functions are never auto-escaped
 					$this,
@@ -1158,7 +1159,7 @@ class Template extends BaseCompiler {
 
 		// check if tag is a block
 		if ($this->smarty->getBlockHandler($base_tag)) {
-			if (!isset($this->smarty->security_policy) || $this->smarty->security_policy->isTrustedTag($base_tag, $this)) {
+			if ($securityPolicy === null || $securityPolicy->isTrustedTag($base_tag, $this)) {
 				return $this->blockCompiler->compile($args, $this, $parameter, $tag, $base_tag);
 			}
 		}

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -195,7 +195,7 @@ class Debug extends Data
         // copy the working dirs from application
         $debObj->setCompileDir($smarty->getCompileDir());
         $debObj->compile_check = Smarty::COMPILECHECK_ON;
-        $debObj->security_policy = null;
+        $debObj->setSecurityPolicy(null);
         $debObj->debugging = false;
         $debObj->debugging_ctrl = 'NONE';
         $debObj->error_reporting = E_ALL & ~E_NOTICE;

--- a/src/FunctionHandler/Fetch.php
+++ b/src/FunctionHandler/Fetch.php
@@ -33,15 +33,16 @@ class Fetch extends Base {
 		if ($protocol !== false) {
 			$protocol = strtolower(substr($params['file'], 0, $protocol));
 		}
-		if (isset($template->getSmarty()->security_policy)) {
+		$securityPolicy = $template->getSmarty()->getSecurityPolicy();
+		if ($securityPolicy !== null) {
 			if ($protocol) {
 				// remote resource (or php stream, …)
-				if (!$template->getSmarty()->security_policy->isTrustedUri($params['file'])) {
+				if (!$securityPolicy->isTrustedUri($params['file'])) {
 					return;
 				}
 			} else {
 				// local file
-				if (!$template->getSmarty()->security_policy->isTrustedResourceDir($params['file'])) {
+				if (!$securityPolicy->isTrustedResourceDir($params['file'])) {
 					return;
 				}
 			}

--- a/src/FunctionHandler/HtmlImage.php
+++ b/src/FunctionHandler/HtmlImage.php
@@ -97,15 +97,16 @@ class HtmlImage extends Base {
 		if ($protocol !== false) {
 			$protocol = strtolower(substr($params['file'], 0, $protocol));
 		}
-		if (isset($template->getSmarty()->security_policy)) {
+		$securityPolicy = $template->getSmarty()->getSecurityPolicy();
+		if ($securityPolicy !== null) {
 			if ($protocol) {
 				// remote resource (or php stream, …)
-				if (!$template->getSmarty()->security_policy->isTrustedUri($params['file'])) {
+				if (!$securityPolicy->isTrustedUri($params['file'])) {
 					return;
 				}
 			} else {
 				// local file
-				if (!$template->getSmarty()->security_policy->isTrustedResourceDir($_image_path)) {
+				if (!$securityPolicy->isTrustedResourceDir($_image_path)) {
 					return;
 				}
 			}

--- a/src/Parser/TemplateParser.php
+++ b/src/Parser/TemplateParser.php
@@ -157,7 +157,7 @@ class TemplateParser
         $this->compiler = $compiler;
         $this->template = $this->compiler->getTemplate();
         $this->smarty = $this->template->getSmarty();
-        $this->security = $this->smarty->security_policy ?? false;
+        $this->security = $this->smarty->getSecurityPolicy() ?? false;
         $this->current_buffer = $this->root_buffer = new TemplateParseTree();
     }
 

--- a/src/Parser/TemplateParser.y
+++ b/src/Parser/TemplateParser.y
@@ -164,7 +164,7 @@ class TemplateParser
         $this->compiler = $compiler;
         $this->template = $this->compiler->getTemplate();
         $this->smarty = $this->template->getSmarty();
-        $this->security = $this->smarty->security_policy ?? false;
+        $this->security = $this->smarty->getSecurityPolicy() ?? false;
         $this->current_buffer = $this->root_buffer = new TemplateParseTree();
     }
 

--- a/src/Resource/BasePlugin.php
+++ b/src/Resource/BasePlugin.php
@@ -86,8 +86,9 @@ abstract class BasePlugin
         $_known_stream = stream_get_wrappers();
         if (in_array($type, $_known_stream)) {
             // is known stream
-            if (is_object($smarty->security_policy)) {
-                $smarty->security_policy->isTrustedStream($type);
+            $securityPolicy = $smarty->getSecurityPolicy();
+            if ($securityPolicy !== null) {
+                $securityPolicy->isTrustedStream($type);
             }
             return $smarty->_resource_handlers[ $type ] = new StreamPlugin();
         }

--- a/src/Resource/FilePlugin.php
+++ b/src/Resource/FilePlugin.php
@@ -40,8 +40,9 @@ class FilePlugin extends BasePlugin {
 		);
 
 		if ($path = $this->getFilePath($source->name, $source->getSmarty(), $source->isConfig)) {
-			if (isset($source->getSmarty()->security_policy) && is_object($source->getSmarty()->security_policy)) {
-				$source->getSmarty()->security_policy->isTrustedResourceDir($path, $source->isConfig);
+			$securityPolicy = $source->getSmarty()->getSecurityPolicy();
+			if ($securityPolicy !== null) {
+				$securityPolicy->isTrustedResourceDir($path, $source->isConfig);
 			}
 			$source->exists = true;
 			$source->timestamp = filemtime($path);

--- a/src/Security.php
+++ b/src/Security.php
@@ -508,7 +508,7 @@ class Security {
 	 */
 	public static function enableSecurity(Smarty $smarty, $security_class) {
 		if ($security_class instanceof Security) {
-			$smarty->security_policy = $security_class;
+			$smarty->setSecurityPolicy($security_class);
 			return $smarty;
 		} elseif (is_object($security_class)) {
 			throw new Exception("Class '" . get_class($security_class) . "' must extend \\Smarty\\Security.");
@@ -521,7 +521,7 @@ class Security {
 		} elseif ($security_class !== Security::class && !is_subclass_of($security_class, Security::class)) {
 			throw new Exception("Class '$security_class' must extend " . Security::class . ".");
 		} else {
-			$smarty->security_policy = new $security_class($smarty);
+			$smarty->setSecurityPolicy(new $security_class($smarty));
 		}
 		return $smarty;
 	}

--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -246,9 +246,9 @@ class Smarty extends \Smarty\TemplateBase {
 	/**
 	 * implementation of security class
 	 *
-	 * @var \Smarty\Security
+	 * @var \Smarty\Security|null
 	 */
-	public $security_policy = null;
+	private $security_policy = null;
 
 	/**
 	 * debug mode
@@ -594,8 +594,29 @@ class Smarty extends \Smarty\TemplateBase {
 	 * @return static current Smarty instance for chaining
 	 */
 	public function disableSecurity() {
-		$this->security_policy = null;
+		$this->setSecurityPolicy(null);
 		return $this;
+	}
+
+	/**
+	 * Set security policy
+	 *
+	 * @param \Smarty\Security|null $policy Security policy instance or null to disable
+	 *
+	 * @return static current Smarty instance for chaining
+	 */
+	public function setSecurityPolicy(?\Smarty\Security $policy) {
+		$this->security_policy = $policy;
+		return $this;
+	}
+
+	/**
+	 * Get security policy
+	 *
+	 * @return \Smarty\Security|null Current security policy instance or null if disabled
+	 */
+	public function getSecurityPolicy(): ?\Smarty\Security {
+		return $this->security_policy;
 	}
 
 	/**
@@ -2229,6 +2250,58 @@ class Smarty extends \Smarty\TemplateBase {
 	 */
 	public function setCacheModifiedCheck($cache_modified_check): void {
 		$this->cache_modified_check = (bool) $cache_modified_check;
+	}
+
+	/**
+	 * Backward compatibility for security_policy property access
+	 *
+	 * @param string $name Property name
+	 *
+	 * @return mixed Property value
+	 */
+	public function __get($name) {
+		if ($name === 'security_policy') {
+			return $this->getSecurityPolicy();
+		}
+		trigger_error('Undefined property: ' . static::class . '::$' . $name, E_USER_NOTICE);
+		return null;
+	}
+
+	/**
+	 * Backward compatibility for security_policy property access with type validation
+	 *
+	 * @param string $name Property name
+	 * @param mixed $value Property value
+	 *
+	 * @return void
+	 * @throws \Smarty\Exception if security_policy value is invalid
+	 */
+	public function __set($name, $value) {
+		if ($name === 'security_policy') {
+			if ($value !== null && !($value instanceof \Smarty\Security)) {
+				$given = is_object($value) ? get_class($value) : gettype($value);
+				throw new \Smarty\Exception(
+					'security_policy must be null or \Smarty\Security, ' . $given . ' given'
+				);
+			}
+			$this->setSecurityPolicy($value);
+			return;
+		}
+		$this->$name = $value;
+	}
+
+	/**
+	 * Check if property is set
+	 *
+	 * @param string $name Property name
+	 *
+	 * @return bool
+	 */
+	public function __isset($name) {
+		if ($name === 'security_policy') {
+			return $this->getSecurityPolicy() !== null;
+		}
+		return isset($this->$name);
 	}
 
 }

--- a/src/Smarty.php
+++ b/src/Smarty.php
@@ -2253,22 +2253,7 @@ class Smarty extends \Smarty\TemplateBase {
 	}
 
 	/**
-	 * Backward compatibility for security_policy property access
-	 *
-	 * @param string $name Property name
-	 *
-	 * @return mixed Property value
-	 */
-	public function __get($name) {
-		if ($name === 'security_policy') {
-			return $this->getSecurityPolicy();
-		}
-		trigger_error('Undefined property: ' . static::class . '::$' . $name, E_USER_NOTICE);
-		return null;
-	}
-
-	/**
-	 * Backward compatibility for security_policy property access with type validation
+	 * Backward compatibility for security_policy property assignment with type validation
 	 *
 	 * @param string $name Property name
 	 * @param mixed $value Property value
@@ -2288,20 +2273,6 @@ class Smarty extends \Smarty\TemplateBase {
 			return;
 		}
 		$this->$name = $value;
-	}
-
-	/**
-	 * Check if property is set
-	 *
-	 * @param string $name Property name
-	 *
-	 * @return bool
-	 */
-	public function __isset($name) {
-		if ($name === 'security_policy') {
-			return $this->getSecurityPolicy() !== null;
-		}
-		return isset($this->$name);
 	}
 
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -135,8 +135,9 @@ class Template extends TemplateBase {
 		$this->source = $_isConfig ? Config::load($this) : Source::load($this);
 		$this->compiled = Compiled::load($this);
 
-		if ($smarty->security_policy) {
-			$smarty->security_policy->registerCallBacks($this);
+		$securityPolicy = $smarty->getSecurityPolicy();
+		if ($securityPolicy !== null) {
+			$securityPolicy->registerCallBacks($this);
 		}
 	}
 

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -30,7 +30,7 @@ class SecurityTest extends PHPUnit_Smarty
 	 */
 	public function testSecurityLoaded()
 	{
-		$this->assertTrue(is_object($this->smarty->security_policy));
+		$this->assertTrue($this->smarty->getSecurityPolicy() instanceof \Smarty\Security);
 	}
 
 	/**
@@ -58,7 +58,7 @@ class SecurityTest extends PHPUnit_Smarty
 	 */
 	public function testNotTrustedModifier()
 	{
-		$this->smarty->security_policy->disabled_modifiers[] = 'escape';
+		$this->smarty->getSecurityPolicy()->disabled_modifiers[] = 'escape';
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('modifier \'escape\' disabled by security setting');
 		@$this->smarty->fetch('string:{assign var=foo value=[1,2,3,4,5]}{$foo|escape}');
@@ -69,7 +69,7 @@ class SecurityTest extends PHPUnit_Smarty
 	 */
 	public function testAllowedTags1()
 	{
-		$this->smarty->security_policy->allowed_tags = array('counter');
+		$this->smarty->getSecurityPolicy()->allowed_tags = array('counter');
 		$this->assertEquals("1", $this->smarty->fetch('string:{counter start=1}'));
 	}
 
@@ -82,7 +82,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('tag \'cycle\' not allowed by security setting');
-		$this->smarty->security_policy->allowed_tags = array('counter');
+		$this->smarty->getSecurityPolicy()->allowed_tags = array('counter');
 		$this->smarty->fetch('string:{counter}{cycle values="1,2"}');
 	}
 
@@ -95,7 +95,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('tag \'cycle\' disabled by security setting');
-		$this->smarty->security_policy->disabled_tags = array('cycle');
+		$this->smarty->getSecurityPolicy()->disabled_tags = array('cycle');
 		$this->smarty->fetch('string:{counter}{cycle values="1,2"}');
 	}
 
@@ -105,14 +105,14 @@ class SecurityTest extends PHPUnit_Smarty
 	public function testAllowedModifier1()
 	{
 		error_reporting(E_ALL  & E_STRICT);
-		$this->smarty->security_policy->allowed_modifiers = array('capitalize');
+		$this->smarty->getSecurityPolicy()->allowed_modifiers = array('capitalize');
 		$this->assertEquals("Hello World", $this->smarty->fetch('string:{"hello world"|capitalize}'));
 		error_reporting(E_ALL | E_STRICT);
 	}
 
 	public function testAllowedModifier2()
 	{
-		$this->smarty->security_policy->allowed_modifiers = array('upper');
+		$this->smarty->getSecurityPolicy()->allowed_modifiers = array('upper');
 		$this->assertEquals("HELLO WORLD", $this->smarty->fetch('string:{"hello world"|upper}'));
 	}
 
@@ -125,7 +125,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('modifier \'lower\' not allowed by security setting');
-		$this->smarty->security_policy->allowed_modifiers = array('upper');
+		$this->smarty->getSecurityPolicy()->allowed_modifiers = array('upper');
 		$this->smarty->fetch('string:{"hello"|upper}{"world"|lower}');
 	}
 
@@ -138,7 +138,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('modifier \'lower\' disabled by security setting');
-		$this->smarty->security_policy->disabled_modifiers = array('lower');
+		$this->smarty->getSecurityPolicy()->disabled_modifiers = array('lower');
 		$this->smarty->fetch('string:{"hello"|upper}{"world"|lower}');
 	}
 
@@ -175,7 +175,7 @@ class SecurityTest extends PHPUnit_Smarty
 	 */
 	public function testTrustedDirectory()
 	{
-		$this->smarty->security_policy->secure_dir = array('.' . DIRECTORY_SEPARATOR . 'templates_2' . DIRECTORY_SEPARATOR);
+		$this->smarty->getSecurityPolicy()->secure_dir = array('.' . DIRECTORY_SEPARATOR . 'templates_2' . DIRECTORY_SEPARATOR);
 		$this->assertEquals("hello world", $this->smarty->fetch('string:{include file="templates_2/hello.tpl"}'));
 	}
 
@@ -189,7 +189,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('not trusted file path');
-		$this->smarty->security_policy->secure_dir = array(str_replace('\\', '/', __DIR__ . '/templates_3/'));
+		$this->smarty->getSecurityPolicy()->secure_dir = array(str_replace('\\', '/', __DIR__ . '/templates_3/'));
 		$this->smarty->fetch('string:{include file="templates_2/hello.tpl"}');
 	}
 
@@ -207,7 +207,7 @@ class SecurityTest extends PHPUnit_Smarty
 	 */
 	public function testTrustedStaticClass()
 	{
-		$this->smarty->security_policy->static_classes = array('mysecuritystaticclass');
+		$this->smarty->getSecurityPolicy()->static_classes = array('mysecuritystaticclass');
 		$tpl = $this->smarty->createTemplate('string:{mysecuritystaticclass::square(5)}');
 		$this->assertEquals('25', $this->smarty->fetch($tpl));
 	}
@@ -221,7 +221,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('access to static class \'mysecuritystaticclass\' not allowed by security setting');
-		$this->smarty->security_policy->static_classes = array('null');
+		$this->smarty->getSecurityPolicy()->static_classes = array('null');
 		$this->smarty->fetch('string:{mysecuritystaticclass::square(5)}');
 	}
 
@@ -232,7 +232,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('dynamic static class not allowed by security setting');
-		$this->smarty->security_policy->static_classes = array('null');
+		$this->smarty->getSecurityPolicy()->static_classes = array('null');
 		$this->smarty->fetch('string:{$test = "mysecuritystaticclass"}{$test::square(5)}');
 	}
 
@@ -243,18 +243,18 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('dynamic static class not allowed by security setting');
-		$this->smarty->security_policy->static_classes = array('null');
+		$this->smarty->getSecurityPolicy()->static_classes = array('null');
 		$this->smarty->fetch('string:{$smarty.template_object::square(5)}');
 	}
 
 	public function testChangedTrustedDirectory()
 	{
-		$this->smarty->security_policy->secure_dir = array(
+		$this->smarty->getSecurityPolicy()->secure_dir = array(
 			'.' . DIRECTORY_SEPARATOR . 'templates_2' . DIRECTORY_SEPARATOR,
 		);
 		$this->assertEquals("hello world", $this->smarty->fetch('string:{include file="templates_2/hello.tpl"}'));
 
-		$this->smarty->security_policy->secure_dir = array(
+		$this->smarty->getSecurityPolicy()->secure_dir = array(
 			'.' . DIRECTORY_SEPARATOR . 'templates_2' . DIRECTORY_SEPARATOR,
 			'.' . DIRECTORY_SEPARATOR . 'templates_3' . DIRECTORY_SEPARATOR,
 		);
@@ -273,7 +273,7 @@ class SecurityTest extends PHPUnit_Smarty
 		$fp = fopen("global://mytest", "r+");
 		fwrite($fp, 'hello world {$foo}');
 		fclose($fp);
-		$this->smarty->security_policy->streams= array('global');
+		$this->smarty->getSecurityPolicy()->streams= array('global');
 		$tpl = $this->smarty->createTemplate('global:mytest');
 		$this->assertTrue($tpl->getSource()->exists);
 		stream_wrapper_unregister("global");
@@ -292,7 +292,7 @@ class SecurityTest extends PHPUnit_Smarty
 		$fp = fopen("global://mytest", "r+");
 		fwrite($fp, 'hello world {$foo}');
 		fclose($fp);
-		$this->smarty->security_policy->streams= array('notrusted');
+		$this->smarty->getSecurityPolicy()->streams= array('notrusted');
 		$tpl = $this->smarty->createTemplate('global:mytest');
 		$this->assertTrue($tpl->getSource()->exists);
 		stream_wrapper_unregister("global");
@@ -300,7 +300,7 @@ class SecurityTest extends PHPUnit_Smarty
 
 	public function testTrustedUri()
 	{
-		$this->smarty->security_policy->trusted_uri = array(
+		$this->smarty->getSecurityPolicy()->trusted_uri = array(
 			'#https://s4otw4nhg.erteorteortert.nusuchtld$#i'
 		);
 
@@ -318,7 +318,7 @@ class SecurityTest extends PHPUnit_Smarty
 	{
 		$this->expectException(\Smarty\Exception::class);
 		$this->expectExceptionMessage('URI \'https://example.net\' not allowed by security setting');
-		$this->smarty->security_policy->trusted_uri = [];
+		$this->smarty->getSecurityPolicy()->trusted_uri = [];
 		$this->assertStringContainsString(
 			'<title>Preface | Smarty</title>',
 			$this->smarty->fetch('string:{fetch file="https://example.net"}')


### PR DESCRIPTION
## Context
This PR fixes some issues where SecurityPolicy checks are silently skipped when the internal security_policy property is overwritten with a non-object value.

Currently, several SecurityPolicy enforcement paths rely on isset() and is_object() checks. If security_policy is set but is not an object, these checks are bypassed without any error, even when enableSecurity() has been called.

This PR makes the behavior more robust and consistent with the intended design of SecurityPolicy by enforcing stricter type handling.


## Changes

- Changed `security_policy` from `public` to `private`
- Added `getSecurityPolicy()` and `setSecurityPolicy()` methods
- Added `__set()` method to validate type on assignment
- Updated all internal code to use getter/setter instead of direct property access
- Updated tests to use `getSecurityPolicy()`