### PR TITLE
fix: correct return type in retrieveCachedContent docblock

### DIFF
--- a/src/Cacheresource/File.php
+++ b/src/Cacheresource/File.php
@@ -143,7 +143,7 @@ class File extends Base
      *
      * @param Template $_template template object
      *
-     * @return string  content
+     * @return string|false content
      */
     public function retrieveCachedContent(Template $_template)
     {


### PR DESCRIPTION
## Summary

Fix incorrect return type in `retrieveCachedContent()` docblock.

Closes  #1175

## Changes

- `@return bool` → `@return string|false`

## Background

The method returns `file_get_contents()` on success, which returns `string`, or `false` when the file does not exist. The previous `@return bool` was inaccurate.

