### PR TITLE
Fix: incorrect `strpos` check in `triggerTagNoCache `

### DIFF
--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -506,7 +506,7 @@ class Template extends BaseCompiler {
 	 * @return string
 	 */
 	public function triggerTagNoCache($variable): void {
-		if (!strpos($variable, '(')) {
+		if (strpos($variable, '(') === false) {
 			// not a variable variable
 			$var = trim($variable, '\'');
 			$this->tag_nocache = $this->tag_nocache |


### PR DESCRIPTION
  ## Description                                                                                                                                                                                   
                                                                                                                                                                                                
  ### Summary                                                                                                                                                                                    
  `triggerTagNoCache()` uses `!strpos($variable, '(')` to check if `(` is absent                                                                                                                
  from `$variable`. However, `strpos` returns `0` when `(` appears at position 0,                                                                                                               
  and `!0` evaluates to `true`, incorrectly skipping the nocache flag logic.                                                                                                                    
                                                                                                                                                                                                
  This replaces `!strpos(...)` with `strpos(...) === false`.                                                                                                                                    
                                                                                                                                                                                                
  ## References                                                                                                                                                                                 
  - https://www.php.net/manual/en/function.strpos.php#refsect1-function.strpos-notes  