### PR TITLE
Fix: TypeError in `Template.php` compiler when prefixCodeStack is empty  

### DIFF
--- a/src/Compiler/Template.php
+++ b/src/Compiler/Template.php
@@ -1075,7 +1075,7 @@ class Template extends BaseCompiler {
 	 */
 	public function getPrefixCode() {
 		$code = '';
-		$prefixArray = array_merge($this->prefix_code, array_pop($this->prefixCodeStack));
+		$prefixArray = array_merge($this->prefix_code, array_pop($this->prefixCodeStack) ?? []);
 		$this->prefixCodeStack[] = [];
 		foreach ($prefixArray as $c) {
 			$code = $this->appendCode($code, (string) $c);


### PR DESCRIPTION
## Description

### Current Problem

`getPrefixCode()` calls `array_pop($this->prefixCodeStack)` and passes the result directly to `array_merge()`. 
When `$prefixCodeStack` is empty, `array_pop()` returns `null`, which causes a `TypeError` on PHP 8.0+:

```
TypeError: array_merge(): Argument #2 must be of type array, null given
```

On PHP 7.x the same call emitted a warning and returned `null`, silently breaking downstream code that expected an array.

## Root cause

There is no guarantee that `prefixCodeStack` is non-empty at the point `getPrefixCode()` is invoked. 
The stack push/pop pairing depends on the compiled template structure, and certain code paths can reach this method with an empty stack.

## Fix

Coalesce the `array_pop()` result to an empty array before merging:

```php
$prefixArray = array_merge($this->prefix_code, array_pop($this->prefixCodeStack) ?? []);
```

This preserves the existing behavior when the stack has elements and returns just `$this->prefix_code` when it is empty, which is the correct semantic.


### Notes

I looked into adding a regression test, but there is no existing unit test covering `Compiler\Template::getPrefixCode()` (or the surrounding prefix-code stack behavior) that I could extend, and the class is not straightforward to instantiate in isolation outside of a full compilation flow. I did not want to introduce a new testing pattern unilaterally in a bug-fix PR. Happy to add a test if maintainers can point me to the preferred approach for unit-testing compiler internals.