### PR TITLE
Fix SSRF bypass of trusted_uri in {fetch} (PT-03-2026)

### DIFF
--- a/changelog/ssrf-pt-03-2026.md
+++ b/changelog/ssrf-pt-03-2026.md
@@ -1,0 +1,1 @@
+- Security: prevent SSRF bypass of `trusted_uri` via redirect-following in `{fetch}`. When a security policy is active, the HTTP stream wrapper no longer auto-follows redirects, so an Open Redirect on a trusted host can no longer be used to reach arbitrary URIs. Reported by Aleksey Solovev (Positive Technologies), PT-03-2026.

--- a/src/FunctionHandler/Fetch.php
+++ b/src/FunctionHandler/Fetch.php
@@ -189,7 +189,19 @@ class Fetch extends Base {
 				return;
 			}
 		} else {
-			$content = @file_get_contents($params['file']);
+			$context = null;
+			if (isset($template->getSmarty()->security_policy)) {
+				// When a security policy is active, the trusted_uri check only validates
+				// the URL passed to {fetch}. PHP's HTTP stream wrapper follows redirects
+				// by default, which would let an Open Redirect on a trusted host bypass
+				// the policy and reach arbitrary internal addresses (SSRF). Disable
+				// redirect following for the policy-checked request. See PT-03-2026.
+				$context = stream_context_create([
+					'http'  => ['follow_location' => 0, 'max_redirects' => 1],
+					'https' => ['follow_location' => 0, 'max_redirects' => 1],
+				]);
+			}
+			$content = @file_get_contents($params['file'], false, $context);
 			if ($content === false) {
 				throw new Exception("{fetch} cannot read resource '" . $params['file'] . "'");
 			}


### PR DESCRIPTION
## Summary
- `{fetch}` with an `https://` (or other non-`http`) URL called `file_get_contents` without a stream context. PHP's HTTP wrapper auto-follows redirects, so an Open Redirect on a trusted host could be used to bypass the `trusted_uri` security policy and reach arbitrary internal addresses (SSRF).
- When `security_policy` is active, the fetch now uses a stream context with `follow_location=0` / `max_redirects=1`. Behaviour is unchanged for users without a security policy (no BC break).
- The `http://` branch goes through `fsockopen`, which never auto-followed redirects, so it was already safe.

## Report
Reported by Aleksey Solovev (Positive Technologies), advisory PT-03-2026. Handled as a normal patch release; no CVE filing requested.

## Files
- `src/FunctionHandler/Fetch.php` — add stream context disabling redirect following under security policy.
- `changelog/ssrf-pt-03-2026.md` — changelog snippet.

## Compatibility
- PHP 7.2–8.5, no API surface change.
- Users without `enableSecurity()` see no behaviour change.