### PR TITLE
Fix misleading error messages with {capture}

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -171,6 +171,7 @@ class Template extends TemplateBase {
 			call_user_func($callback, $this);
 		}
 
+		$renderException = null;
 		try {
 
 			// read from cache or render
@@ -180,9 +181,21 @@ class Template extends TemplateBase {
 				$this->getCompiled()->render($this);
 			}
 
+		} catch (\Throwable $e) {
+			$renderException = $e;
 		} finally {
-			foreach ($this->endRenderCallbacks as $callback) {
-				call_user_func($callback, $this);
+			try {
+				foreach ($this->endRenderCallbacks as $callback) {
+					call_user_func($callback, $this);
+				}
+			} catch (\Throwable $callbackException) {
+				if ($renderException === null) {
+					throw $callbackException;
+				}
+			}
+
+			if ($renderException !== null) {
+				throw $renderException;
 			}
 		}
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -183,6 +183,7 @@ class Template extends TemplateBase {
 
 		} catch (\Throwable $e) {
 			$renderException = $e;
+            throw $renderException;
 		} finally {
 			try {
 				foreach ($this->endRenderCallbacks as $callback) {
@@ -192,10 +193,6 @@ class Template extends TemplateBase {
 				if ($renderException === null) {
 					throw $callbackException;
 				}
-			}
-
-			if ($renderException !== null) {
-				throw $renderException;
 			}
 		}
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -183,7 +183,7 @@ class Template extends TemplateBase {
 
 		} catch (\Throwable $e) {
 			$renderException = $e;
-            throw $renderException;
+			throw $renderException;
 		} finally {
 			try {
 				foreach ($this->endRenderCallbacks as $callback) {

--- a/tests/UnitTests/TemplateSource/TagTests/Capture/CompileCaptureTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Capture/CompileCaptureTest.php
@@ -97,6 +97,31 @@ class CompileCaptureTest extends PHPUnit_Smarty
         $this->assertStringContainsString('uppercase', $result);
     }
 
+    public function testRenderExceptionInsideCaptureIsNotMaskedByEndRenderException()
+    {
+        $this->smarty->registerPlugin(\Smarty\Smarty::PLUGIN_FUNCTION, 'capture_fail', function () {
+            throw new \RuntimeException('render failure inside capture');
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('render failure inside capture');
+
+        $this->smarty->fetch('string:{capture}{capture_fail}{/capture}');
+    }
+
+    public function testEndRenderCallbackExceptionIsThrownWhenRenderSucceeds()
+    {
+        $template = $this->smarty->createTemplate('string:render succeeds');
+        $template->endRenderCallbacks[] = function () {
+            throw new \RuntimeException('end render callback failure');
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('end render callback failure');
+
+        $template->fetch();
+    }
+
     /**
      * Test spacings
      *


### PR DESCRIPTION
Fixes #1032

## What does this fix?

This fixes misleading error reporting when an exception is thrown while rendering content inside a `{capture}` block.

Before this change, the original render exception could be hidden by a later `CaptureRuntime::endRender()` exception:

```text
Not matching {capture}{/capture}
```

That made debugging harder, because the developer had to remove or inspect the {capture} block to find the real error.
# What changed?
Template::render() now keeps track of an exception thrown during the actual render phase.
The endRenderCallbacks are still executed in finally, preserving the cleanup behavior. However, if rendering has already failed and an endRenderCallback also throws, the callback exception no longer replaces the original render exception.
If rendering succeeds, callback exceptions keep the previous behavior and are still thrown normally.
# Behavior after this change
• If rendering fails inside {capture}, the original render exception is reported.
• If rendering succeeds but an endRenderCallback fails, that callback exception is still reported.
• If both rendering and an endRenderCallback fail, the original render exception wins.