### PR TITLE
Fix PHP 8.1 "Passing null to parameter" deprecations in regex_replace modifier

### DIFF
--- a/src/Extension/DefaultExtension.php
+++ b/src/Extension/DefaultExtension.php
@@ -670,7 +670,9 @@ class DefaultExtension extends Base {
 		} else {
 			$search = $this->regex_replace_check($search);
 		}
-		return preg_replace($search, $replace, $string, $limit);
+		// provide defaults to prevent deprecation errors in PHP >=8.1
+		// a null $limit falls back to 0, matching PHP's historical null-to-int coercion
+		return preg_replace($search, $replace ?? '', $string ?? '', $limit ?? 0);
 	}
 
 	/**
@@ -681,6 +683,8 @@ class DefaultExtension extends Base {
 	 */
 	private function regex_replace_check($search)
 	{
+		// provide $search default to prevent deprecation errors in PHP >=8.1
+		$search = $search ?? '';
 		// null-byte injection detection
 		// anything behind the first null-byte is ignored
 		if (($pos = strpos($search, "\0")) !== false) {

--- a/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierRegexReplaceTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginModifier/PluginModifierRegexReplaceTest.php
@@ -26,6 +26,37 @@ class PluginModifierRegexReplaceTest extends PHPUnit_Smarty
         $this->assertEquals("Infertility unlikely to be passed on, experts say.", $this->smarty->fetch($tpl));
     }
 
+    public function testWithNull()
+    {
+        // the test suite mutes E_DEPRECATED globally, so collect deprecations manually
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            $deprecations[] = $errstr;
+            return true;
+        }, E_DEPRECATED);
+
+        try {
+            $this->smarty->assign('subject', null);
+            $tpl = $this->smarty->createTemplate('string:{$subject|regex_replace:"/[\r\t\n]/":" "}');
+            $this->assertEquals("", $this->smarty->fetch($tpl));
+
+            // null replacement removes the match
+            $this->smarty->assign('replacement', null);
+            $tpl = $this->smarty->createTemplate('string:{"a\nb"|regex_replace:"/[\r\t\n]/":$replacement}');
+            $this->assertEquals("ab", $this->smarty->fetch($tpl));
+
+            // null limit keeps behaving as 0 (no replacements), as PHP's null-to-int
+            // coercion did before the deprecation
+            $this->smarty->assign('limit', null);
+            $tpl = $this->smarty->createTemplate('string:{"a\nb\nc"|regex_replace:"/[\r\t\n]/":" ":$limit}');
+            $this->assertEquals("a\nb\nc", $this->smarty->fetch($tpl));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertEquals([], $deprecations);
+    }
+
     public function testUmlauts()
     {
         $tpl = $this->smarty->createTemplate('string:{"Infertility unlikely tö\näe passed on, experts say."|regex_replace:"/[\r\t\n]/u":" "}');


### PR DESCRIPTION
## Problem

The `regex_replace` modifier triggers `Passing null to parameter` deprecation errors on PHP >= 8.1 when any of its arguments is `null`, e.g. when a template variable holds `null` or was never assigned:

```smarty
{$nullableVar|regex_replace:"/[\r\t\n]/":" "}
```

```
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```

The same applies to:

- a `null` search pattern (`strpos()` and `preg_match()` inside `regex_replace_check()`, and `preg_replace()`'s `$pattern`)
- a `null` replacement (`preg_replace()`'s `$replacement`)
- a `null` limit (`preg_replace()`'s `$limit`)

## Fix

Follow the existing convention already used in `DefaultExtension` for `number_format`, `explode`, `split` and `implode` (see the "provide $string default to prevent deprecation errors in PHP >=8.1" comments): coalesce `null` arguments before passing them on.
Note on backwards compatibility: this is strictly a deprecation fix and does
not change any output.

- `$string ?? ''` and `$replace ?? ''` produce exactly what PHP's implicit null-to-string coercion produced before.
- `$limit ?? 0` deliberately falls back to `0` (not the parameter default `-1`), because PHP's null-to-int coercion has always turned a `null` limit into `0` (i.e. no replacements). Falling back to `-1` would silently change the output of existing templates that pass a null limit. A comment in the code documents this.

## Tests

Added a test covering all three null cases. Since the test suite mutes `E_DEPRECATED` globally (`PHPUnit_Smarty::setUp()`), the test also collects deprecations via a temporary error handler and asserts that none are raised — running it without the fix fails with the three deprecations listed above, and with the fix all existing `PluginModifier` tests still pass unchanged.

This is the same kind of fix as #834 / #838 / #1135.