### PR TITLE
Fix float to int deprecation in "is odd by" / "is even by" operators

### DIFF
--- a/src/Parser/TemplateParser.php
+++ b/src/Parser/TemplateParser.php
@@ -2566,7 +2566,7 @@ public static $yy_action = array(
     }
 // line 655 "src/Parser/TemplateParser.y"
     public function yy_r72(){
-    $this->_retvalue = $this->yystack[$this->yyidx + -1]->minor['pre']. $this->yystack[$this->yyidx + -2]->minor.$this->yystack[$this->yyidx + -1]->minor['op'].$this->yystack[$this->yyidx + 0]->minor .')';
+    $this->_retvalue = $this->yystack[$this->yyidx + -1]->minor['pre']. $this->yystack[$this->yyidx + -2]->minor.$this->yystack[$this->yyidx + -1]->minor['op'].$this->yystack[$this->yyidx + 0]->minor .$this->yystack[$this->yyidx + -1]->minor['post'];
     }
 // line 659 "src/Parser/TemplateParser.y"
     public function yy_r73(){
@@ -3001,12 +3001,12 @@ public static $yy_action = array(
 // line 1302 "src/Parser/TemplateParser.y"
     public function yy_r182(){
      static $tlops = array(
-         'isdivby' => array('op' => ' % ', 'pre' => '!('),
-         'isnotdivby' => array('op' => ' % ', 'pre' => '('),
-         'isevenby' => array('op' => ' / ', 'pre' => '!(1 & '),
-         'isnotevenby' => array('op' => ' / ', 'pre' => '(1 & '),
-         'isoddby' => array('op' => ' / ', 'pre' => '(1 & '),
-         'isnotoddby' => array('op' => ' / ', 'pre' => '!(1 & '),
+         'isdivby' => array('op' => ' % ', 'pre' => '!(', 'post' => ')'),
+         'isnotdivby' => array('op' => ' % ', 'pre' => '(', 'post' => ')'),
+         'isevenby' => array('op' => ' / ', 'pre' => '!(1 & (int)(', 'post' => '))'),
+         'isnotevenby' => array('op' => ' / ', 'pre' => '(1 & (int)(', 'post' => '))'),
+         'isoddby' => array('op' => ' / ', 'pre' => '(1 & (int)(', 'post' => '))'),
+         'isnotoddby' => array('op' => ' / ', 'pre' => '!(1 & (int)(', 'post' => '))'),
          );
      $op = strtolower(preg_replace('/\s*/', '', $this->yystack[$this->yyidx + 0]->minor));
      $this->_retvalue = $tlops[$op];

--- a/src/Parser/TemplateParser.y
+++ b/src/Parser/TemplateParser.y
@@ -653,7 +653,7 @@ expr(res)        ::= expr(e) UNIMATH(m) value(v). {
 // if expression
                     // special conditions
 expr(res)        ::= expr(e1) tlop(c) value(e2). {
-    res = c['pre']. e1.c['op'].e2 .')';
+    res = c['pre']. e1.c['op'].e2 .c['post'];
 }
                     // simple expression
 expr(res)        ::= expr(e1) lop(c) expr(e2). {
@@ -1301,12 +1301,12 @@ lop(res)        ::= SLOGOP(o). {
 }
 tlop(res)        ::= TLOGOP(o). {
      static $tlops = array(
-         'isdivby' => array('op' => ' % ', 'pre' => '!('),
-         'isnotdivby' => array('op' => ' % ', 'pre' => '('),
-         'isevenby' => array('op' => ' / ', 'pre' => '!(1 & '),
-         'isnotevenby' => array('op' => ' / ', 'pre' => '(1 & '),
-         'isoddby' => array('op' => ' / ', 'pre' => '(1 & '),
-         'isnotoddby' => array('op' => ' / ', 'pre' => '!(1 & '),
+         'isdivby' => array('op' => ' % ', 'pre' => '!(', 'post' => ')'),
+         'isnotdivby' => array('op' => ' % ', 'pre' => '(', 'post' => ')'),
+         'isevenby' => array('op' => ' / ', 'pre' => '!(1 & (int)(', 'post' => '))'),
+         'isnotevenby' => array('op' => ' / ', 'pre' => '(1 & (int)(', 'post' => '))'),
+         'isoddby' => array('op' => ' / ', 'pre' => '(1 & (int)(', 'post' => '))'),
+         'isnotoddby' => array('op' => ' / ', 'pre' => '!(1 & (int)(', 'post' => '))'),
          );
      $op = strtolower(preg_replace('/\s*/', '', o));
      res = $tlops[$op];

--- a/tests/UnitTests/TemplateSource/TagTests/If/CompileIfTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/If/CompileIfTest.php
@@ -285,5 +285,50 @@ class CompileIfTest extends PHPUnit_Smarty
         );
     }
 
+    /**
+     * Test that "is [not] even by" / "is [not] odd by" do not trigger
+     * "Implicit conversion from float to int loses precision" (PHP 8.1+)
+     * when the division has a remainder.
+     *
+     * @dataProvider        dataTestIsOddEvenByNoDeprecation
+     */
+    public function testIsOddEvenByNoDeprecation($code, $result, $testName)
+    {
+        $errors = array();
+        set_error_handler(function ($errno, $errstr) use (&$errors) {
+            $errors[] = $errstr;
+            return true;
+        }, E_ALL);
+        try {
+            $file = "testIf_{$testName}.tpl";
+            $this->makeTemplateFile($file, $code);
+            $this->smarty->assign('index', 1);
+            $this->smarty->assign('by', 2);
+            $this->smarty->assign('float', 2.5);
+            $output = $this->smarty->fetch($file);
+        } finally {
+            restore_error_handler();
+        }
+        $this->assertEquals($result, $output, "testIsOddEvenByNoDeprecation - {$code}");
+        $this->assertSame(array(), $errors, "testIsOddEvenByNoDeprecation - {$code}");
+    }
 
+    /*
+      * Data provider for testIsOddEvenByNoDeprecation
+      */
+    public function dataTestIsOddEvenByNoDeprecation()
+    {
+        return array(
+            array('{if 1 is odd by 2}yes{else}no{/if}', 'no', 'IsOddByRemainder1'),
+            array('{if 3 is odd by 2}yes{else}no{/if}', 'yes', 'IsOddByRemainder3'),
+            array('{if 1 is not odd by 2}yes{else}no{/if}', 'yes', 'IsNotOddByRemainder1'),
+            array('{if 1 is even by 2}yes{else}no{/if}', 'yes', 'IsEvenByRemainder1'),
+            array('{if 3 is even by 2}yes{else}no{/if}', 'no', 'IsEvenByRemainder3'),
+            array('{if 3 is not even by 2}yes{else}no{/if}', 'yes', 'IsNotEvenByRemainder3'),
+            array('{if $index is odd by $by}yes{else}no{/if}', 'no', 'IsOddByVarRemainder'),
+            array('{if ($index+2) is odd by $by}yes{else}no{/if}', 'yes', 'IsOddByExprRemainder'),
+            array('{if $float is odd by 1}yes{else}no{/if}', 'no', 'IsOddByFloatVar'),
+            array('{if $float is even by 1}yes{else}no{/if}', 'yes', 'IsEvenByFloatVar'),
+        );
+    }
  }


### PR DESCRIPTION
Fixes #1208

Hi!

`is [not] odd by` / `is [not] even by` compile to `(1 & $a / $b)`.
When the division has a remainder, the bitwise AND triggers "Implicit conversion from float to int loses precision" on PHP 8.1+.
The division result is now cast to int explicitly (`(1 & (int)($a / $b))`), which matches the implicit truncation PHP was already doing, so template output is unchanged.

Thank you!